### PR TITLE
Don't require bash for building.

### DIFF
--- a/setup/echo.sh
+++ b/setup/echo.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 echo $*


### PR DESCRIPTION
Most BSD neither ship bash nor install it in /bin. the echo.sh script
can safely use /bin/sh which is a more portable option.

I guess more shebang could be fixed (bash & perl) but this one will prevent building. Tested under FreeBSD 11.0-CURRENT and DragonFly v3.7.1.71.gc6cad5-DEVELOPMENT.
