### PR TITLE
Don't require bash for building. (with signed-off-by this time)

### DIFF
--- a/setup/echo.sh
+++ b/setup/echo.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 echo $*


### PR DESCRIPTION
  Most BSD neither ship bash nor install it in /bin. the echo.sh script
  can safely use /bin/sh which is a more portable option.

  Signed-off-by: Alexandre Perrin alex@kaworu.ch
