### PR TITLE
Restrict a file name to naming convention for OCaml modules

### DIFF
--- a/commons/common.ml
+++ b/commons/common.ml
@@ -286,6 +286,40 @@ let pr2_xxxxxxxxxxxxxxxxx () =
   pr2 "-----------------------------------------------------------------------"
 
 
+exception Inappropriate_string
+
+let generate_safe_id name =
+  let length = String.length name in
+    if length < 1 then
+      raise Inappropriate_string
+    else
+      begin
+        let part = Buffer.create length in
+        begin
+          if Str.string_match (Str.regexp "^[a-zA-Z]$") (Char.escaped name.[0]) 0 then
+            Buffer.add_char part name.[0]
+          else
+            Buffer.add_char part 'X'
+        end;
+
+        if length > 1 then
+          begin
+            let pattern = Str.regexp "^[a-zA-Z0-9]$" in
+
+            for x = 1 to length - 1 do
+              if Str.string_match pattern (Char.escaped name.[x]) 0 then
+                Buffer.add_char part name.[x]
+              else
+                Buffer.add_char part '_'
+            done;
+
+            Buffer.contents part
+          end
+        else
+          Buffer.contents part
+      end
+
+
 let reset_pr_indent () =
   _tab_level_print := 0
 

--- a/commons/common.mli
+++ b/commons/common.mli
@@ -2011,3 +2011,7 @@ class ['a] olist :
 
 val typing_sux_test : unit -> unit
 
+
+exception Inappropriate_string
+
+val generate_safe_id : string -> string

--- a/ocaml/yes_prepare_ocamlcocci.ml
+++ b/ocaml/yes_prepare_ocamlcocci.ml
@@ -266,9 +266,7 @@ let prepare coccifile code =
   then None
   else
     begin
-      let basefile = Filename.basename (Filename.chop_extension coccifile) in
-      let basefile =
-	String.concat "_" (Str.split (Str.regexp "-") basefile) in
+      let basefile = Common.generate_safe_id (Filename.basename (Filename.chop_extension coccifile)) in
       let (file,o) = Filename.open_temp_file  basefile ".ml" in
       (* Global initialization *)
       Printf.fprintf o "%s\n" (init_ocamlcocci());


### PR DESCRIPTION
External tools will be called for the transformation of an OCaml source file into an executable program. The corresponding file name was treated in a way that the used parameter could be split into separate parts if [it contained special characters like spaces](https://github.com/coccinelle/coccinelle/issues/5).

A name split could result in unwanted consequences.
- Different files would be referenced.
- The files would not be found with shorter names.

This situation can be improved in the way that a specific identifier which will fit to the naming convention for OCaml modules will be generated.
