### PR TITLE
Fix typo in AC_COCCI_TOOL

### DIFF
--- a/setup/cocci.m4
+++ b/setup/cocci.m4
@@ -285,7 +285,7 @@ AC_DEFUN([AC_COCCI_TOOL],
     AC_SUBST([$1], [no])
   ],
   [dnl  find the tool
-    AC_COCCI_FINDTOOL([$1],[[$]$1])
+    AC_COCCI_FINDTOOL([$1],[$2])
   ])
 
   AS_IF([test -z "[$]$1" -o "x[$]$1" = xno],


### PR DESCRIPTION
Without this change ocamlfind is not found.

Signed-off-by: Olaf Hering <olaf@aepfle.de>