### PR TITLE
install.txt: add libparmap-ocaml-dev to the build requirements

### DIFF
--- a/install.txt
+++ b/install.txt
@@ -24,6 +24,7 @@ On Debian/Ubuntu, install the following packages
  - ocaml-findlib
  - menhir and libmenhir-ocaml-dev (optional, bundled)
  - libpcre-ocaml-dev (optional, bundled)
+ - libparmap-ocaml-dev
  - texlive-fonts-extra (for the documentation)
 
 On Fedora, install the following packages


### PR DESCRIPTION
Lack of `libparmap-ocaml-dev` produces below compilation error in Ubuntu 16.04:
```
make[5]: Leaving directory '/tmp/coccinelle/tools/spgen'
make[4]: Leaving directory '/tmp/coccinelle'
make[3]: Leaving directory '/tmp/coccinelle'
make spatch.opt BUILD_OPT=yes
make[3]: Entering directory '/tmp/coccinelle'
make[3]: *** No rule to make target '/usr/lib/ocaml/parmap/parmap.cmxa', needed by 'spatch.opt'.  Stop.
make[3]: Leaving directory '/tmp/coccinelle'
Makefile:164: recipe for target 'opt-compil' failed
make[2]: *** [opt-compil] Error 2
make[2]: Leaving directory '/tmp/coccinelle'
Makefile:144: recipe for target 'all-release' failed
make[1]: *** [all-release] Error 2
make[1]: Leaving directory '/tmp/coccinelle'
Makefile:122: recipe for target 'all' failed
make: *** [all] Error 2
```