### PR TITLE
Improve several dependency specifications in make rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ TARGET=spatch
 PRJNAME=coccinelle
 ML_FILES=flag_cocci.ml cocci.ml testing.ml $(LEXER_SOURCES:.mll=.ml) \
 read_options.ml main.ml
-MLI_FILES=cocci.mli testing.mli
+MLI_FILES=cocci.mli read_options.mli testing.mli
 
 ifeq ($(FEATURE_PYTHON),1)
 	PYTHON_INSTALL_TARGET=install-python
@@ -515,15 +515,12 @@ tags:
 
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
-	$(OCAMLC_CMD) -c $<
-.mli.cmi:
-	$(OCAMLC_CMD) -c $<
-.ml.cmx:
-	$(OCAMLOPT_CMD) -c $<
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/common_rules.make
 
-.ml.mldepend:
-	$(OCAMLC_CMD) -i $<
+modules_with_mli::=$(basename $(MLI_FILES))
+include $(abs_top_srcdir)/rule_pair2.make
+endif
 
 clean distclean::
 	rm -f .depend

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -51,6 +51,12 @@ includedir=@includedir@
 libdir=@libdir@
 sysconfdir=@sysconfdir@
 mandir=@mandir@
+abs_top_srcdir::=@abs_top_srcdir@
+
+ifneq ($(use_separate_build_directory),)
+abs_top_builddir::=@abs_top_builddir@
+VPATH::=$(abs_top_builddir)
+endif
 
 # C compiler
 export CC=@CC@

--- a/common_rules.make
+++ b/common_rules.make
@@ -1,0 +1,15 @@
+# This file is part of Coccinelle, licensed under the terms of the GPL v2.
+# See copyright.txt in the Coccinelle source code for more information.
+# The Coccinelle source code can be obtained at http://coccinelle.lip6.fr
+
+.mli.cmi:
+	$(OCAMLC_CMD) -c $<
+
+.ml.cmo:
+	$(OCAMLC_CMD) -c $<
+
+.ml.cmx:
+	$(OCAMLOPT_CMD) -c $<
+
+.ml.mldepend:
+	$(OCAMLC_CMD) -i $<

--- a/commons/Makefile
+++ b/commons/Makefile
@@ -17,8 +17,6 @@ MYSRC=	commands.ml                              \
 
 MLI_FILES=\
   common.mli \
-  objet.mli \
-  ocollection.mli \
   ograph_extended.mli \
   ograph_simple.mli
 
@@ -208,12 +206,12 @@ dependencygraph2:
 .SUFFIXES:
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
-	$(OCAMLC_CMD)  -c $<
-.mli.cmi:
-	$(OCAMLC_CMD)  -c $<
-.ml.cmx:
-	$(OCAMLOPT_CMD)  -c $<
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/common_rules.make
+
+modules_with_mli::=$(basename $(MLI_FILES))
+include $(abs_top_srcdir)/rule_pair2.make
+endif
 
 clean::
 	rm -f *.cm[iox] *.o *.a *.cma *.cmxa *.annot

--- a/ctl/Makefile
+++ b/ctl/Makefile
@@ -9,7 +9,8 @@ endif
 
 TARGET=ctl
 
-SRC=flag_ctl.ml ast_ctl.ml pretty_print_ctl.ml ctl_engine.ml wrapper_ctl.ml
+SRC_without_mli::=ast_ctl.ml flag_ctl.ml
+SRC_with_mli::=ctl_engine.ml pretty_print_ctl.ml wrapper_ctl.ml
 
 SYSLIBS=str.cma unix.cma
 LIBS=../commons/commons.cma ../globals/globals.cma
@@ -30,9 +31,9 @@ OCAMLMKTOP_CMD=$(OCAMLMKTOP) -g -custom $(INCLUDES)
 LIB=$(TARGET).cma
 OPTLIB=$(LIB:.cma=.cmxa)
 
-OBJS = $(SRC:.ml=.cmo)
-OPTOBJS = $(SRC:.ml=.cmx)
-
+working_order::=flag_ctl ast_ctl pretty_print_ctl ctl_engine wrapper_ctl
+OBJS::=$(addsuffix .cmo,$(working_order))
+OPTOBJS::=$(addsuffix .cmx,$(working_order))
 
 all: $(LIB)
 all.opt:
@@ -54,15 +55,18 @@ clean::
 .SUFFIXES:
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/common_rules.make
+include $(abs_top_srcdir)/rule_pair.make
+
+pretty_print_ctl.cmo: pretty_print_ctl.ml pretty_print_ctl.cmi \
+../commons/common.cmi
 	$(OCAMLC_CMD) -c $<
 
-.mli.cmi:
-	$(OCAMLC_CMD) -c $<
-
-.ml.cmx:
+pretty_print_ctl.cmx: pretty_print_ctl.ml pretty_print_ctl.cmi \
+../commons/common.cmi
 	$(OCAMLOPT_CMD) -c $<
-
+endif
 
 # clean rule for other files
 clean::

--- a/engine/Makefile
+++ b/engine/Makefile
@@ -11,8 +11,8 @@ include ../Makefile.config
 -include ../Makefile.local
 endif
 
-TARGET=cocciengine
-CTLTARGET=engine
+TARGET::=engine
+TARGET_ALIAS::=cocciengine
 
 SRC= flag_matcher.ml lib_engine.ml pretty_print_engine.ml \
       check_exhaustive_pattern.ml \
@@ -58,21 +58,21 @@ OPTOBJS = $(SRC:.ml=.cmx)
 ##############################################################################
 # Top rules
 ##############################################################################
-all: $(TARGET).cma
+all: $(TARGET_ALIAS).cma
 all.opt:
-	@$(MAKE) $(TARGET).cmxa BUILD_OPT=yes
+	@$(MAKE) $(TARGET_ALIAS).cmxa BUILD_OPT=yes
 
-$(TARGET).cma: $(OBJS)
-	$(OCAMLC_CMD) -a -o $(TARGET).cma $(OBJS)
+$(TARGET_ALIAS).cma: $(OBJS)
+	$(OCAMLC_CMD) -a -o $(TARGET_ALIAS).cma $(OBJS)
 
-$(TARGET).cmxa: $(OPTOBJS) $(LIBS:.cma=.cmxa)
-	$(OCAMLOPT_CMD) -a -o $(TARGET).cmxa $(OPTOBJS)
+$(TARGET_ALIAS).cmxa: $(OPTOBJS) $(LIBS:.cma=.cmxa)
+	$(OCAMLOPT_CMD) -a -o $(TARGET_ALIAS).cmxa $(OPTOBJS)
 
-$(TARGET).top: $(OBJS) $(LIBS)
-	$(OCAMLMKTOP_CMD) -o $(TARGET).top $(SYSLIBS) $(LIBS) $(OBJS)
+$(TARGET_ALIAS).top: $(OBJS) $(LIBS)
+	$(OCAMLMKTOP_CMD) -o $(TARGET_ALIAS).top $(SYSLIBS) $(LIBS) $(OBJS)
 
 clean::
-	rm -f $(TARGET).top
+	rm -f $(TARGET_ALIAS).top
 
 ##############################################################################
 # Pad's rules
@@ -84,15 +84,9 @@ clean::
 
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
-	$(OCAMLC_CMD) -c $<
-.mli.cmi:
-	$(OCAMLC_CMD) -c $<
-.ml.cmx:
-	$(OCAMLOPT_CMD) -c $<
-
-.ml.mldepend:
-	$(OCAMLC_CMD) -i $<
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/modules_with_mli.make
+endif
 
 clean::
 	rm -f *.cm[ioxa] *.o *.a *.cmxa *.annot

--- a/extra/Makefile
+++ b/extra/Makefile
@@ -51,15 +51,15 @@ clean::
 
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
-	$(OCAMLC_CMD) -c $<
-.mli.cmi:
-	$(OCAMLC_CMD) -c $<
-.ml.cmx:
-	$(OCAMLOPT_CMD) -c $<
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/common_rules.make
 
-.ml.mldepend:
-	$(OCAMLC_CMD) -i $<
+$(OBJS): %.cmo: %.ml %.cmi
+	$(OCAMLC_CMD) -c $<
+
+$(OPTOBJS): %.cmx: %.ml %.cmi
+	$(OCAMLOPT_CMD) -c $<
+endif
 
 clean::
 	rm -f .depend

--- a/globals/Makefile
+++ b/globals/Makefile
@@ -15,7 +15,8 @@ TARGET=globals
 OCAMLCFLAGS ?= -g
 OPTFLAGS ?= -g
 
-SRC=config.ml flag.ml iteration.ml $(REGEXP_FILE) regexp.ml
+SRC_without_mli::=config.ml flag.ml $(REGEXP_FILE) regexp.ml
+SRC_with_mli::=iteration.ml
 
 LIBS=
 INCLUDEDIRS= ../commons $(PCREDIR)
@@ -30,8 +31,8 @@ OCAMLOPT_CMD=$(OCAMLOPT) $(OPTFLAGS) $(INCLUDES)
 OCAMLDEP_CMD=$(OCAMLDEP) $(INCLUDES)
 OCAMLMKTOP_CMD=$(OCAMLMKTOP) -g -custom $(INCLUDES)
 
-OBJS= $(SRC:.ml=.cmo)
-OPTOBJS= $(SRC:.ml=.cmx)
+OBJS::=$(SRC_without_mli:.ml=.cmo) $(SRC_with_mli:.ml=.cmo)
+OPTOBJS::=$(SRC_without_mli:.ml=.cmx) $(SRC_with_mli:.ml=.cmx)
 
 ##############################################################################
 # Top rules
@@ -52,15 +53,16 @@ $(TARGET).cmxa: $(LIBS:.cma=.cmxa) $(OPTOBJS)
 ##############################################################################
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
-	$(OCAMLC_CMD) -c $<
-.mli.cmi:
-	$(OCAMLC_CMD) -c $<
-.ml.cmx:
-	$(OCAMLOPT_CMD) -c $<
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/common_rules.make
+include $(abs_top_srcdir)/rule_pair.make
 
-.ml.mldepend:
-	$(OCAMLC_CMD) -i $<
+iteration.cmo: iteration.ml iteration.cmi
+	$(OCAMLC_CMD) -c $<
+
+iteration.cmx: iteration.ml iteration.cmi
+	$(OCAMLOPT_CMD) -c $<
+endif
 
 clean:
 	rm -f *.cm[ioxa] *.o *.a *.cmxa *.annot

--- a/modules_with_mli.make
+++ b/modules_with_mli.make
@@ -1,0 +1,20 @@
+# This file is part of Coccinelle, licensed under the terms of the GPL v2.
+# See copyright.txt in the Coccinelle source code for more information.
+# The Coccinelle source code can be obtained at http://coccinelle.lip6.fr
+
+include $(abs_top_srcdir)/common_rules.make
+
+x_modules_with_mli_source_dir::=$(abs_top_srcdir)/$(TARGET)/
+x_modules_with_mli_sources::=$(wildcard $(x_modules_with_mli_source_dir)*.mli)
+
+ifeq ($(x_modules_with_mli_sources),)
+$(error Required interface descriptions were not found in this directory: $(x_modules_with_mli_source_dir))
+else
+modules_with_mli::=$(basename $(subst $(x_modules_with_mli_source_dir),,$(x_modules_with_mli_sources)))
+
+ifeq ($(MAKE_RESTARTS),)
+$(info $(words $(modules_with_mli)) modules with mli files)
+endif
+
+include $(abs_top_srcdir)/rule_pair2.make
+endif

--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -7,7 +7,8 @@ include ../Makefile.config
 -include ../Makefile.local
 endif
 
-TARGET=cocciocaml
+TARGET::=ocaml
+TARGET_ALIAS::=cocciocaml
 
 SRC=externalanalysis.ml \
 	exposed_modules.ml coccilib.ml ocamlcocci_aux.ml $(OCAMLCOCCI_FILE) \
@@ -43,24 +44,24 @@ OPTOBJS = $(SRC:.ml=.cmx)
 ##############################################################################
 # Top rules
 ##############################################################################
-all: $(TARGET).cma
+all: $(TARGET_ALIAS).cma
 all.opt:
-	@$(MAKE) $(TARGET).cmxa BUILD_OPT=yes
+	@$(MAKE) $(TARGET_ALIAS).cmxa BUILD_OPT=yes
 
-$(TARGET).cma: $(OBJS)
-	$(OCAMLC_CMD) -a -o $(TARGET).cma $(OBJS)
+$(TARGET_ALIAS).cma: $(OBJS)
+	$(OCAMLC_CMD) -a -o $(TARGET_ALIAS).cma $(OBJS)
 	for i in `grep " (\*" exposed_modules.ml | sed "s/^.*(\* //" | sed "s/\..* \*)$$//"`; do cp ../$$i.cmi .; done
 
-$(TARGET).cmxa: $(OPTOBJS) $(LIBS:.cma=.cmxa)
-	$(OCAMLOPT_CMD) -a -o $(TARGET).cmxa $(OPTOBJS)
+$(TARGET_ALIAS).cmxa: $(OPTOBJS) $(LIBS:.cma=.cmxa)
+	$(OCAMLOPT_CMD) -a -o $(TARGET_ALIAS).cmxa $(OPTOBJS)
 	for i in `grep " (\*" exposed_modules.ml | sed "s/^.*(\* //" | sed "s/\..* \*)$$//"`; do cp ../$$i.cmi .; done
 	for i in `grep " (\*" exposed_modules.ml | sed "s/^.*(\* //" | sed "s/\..* \*)$$//"`; do cp ../$$i.cmx .; done
 
-$(TARGET).top: $(OBJS) $(LIBS)
-	$(OCAMLMKTOP_CMD) -o $(TARGET).top $(SYSLIBS) $(LIBS) $(OBJS)
+$(TARGET_ALIAS).top: $(OBJS) $(LIBS)
+	$(OCAMLMKTOP_CMD) -o $(TARGET_ALIAS).top $(SYSLIBS) $(LIBS) $(OBJS)
 
 clean::
-	rm -f $(TARGET).top
+	rm -f $(TARGET_ALIAS).top
 
 include Makefile.doc
 
@@ -75,15 +76,9 @@ include Makefile.doc
 
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
-	$(OCAMLC_CMD) -c $<
-.mli.cmi:
-	$(OCAMLC_CMD) -c $<
-.ml.cmx:
-	$(OCAMLOPT_CMD) -c $<
-
-.ml.mldepend:
-	$(OCAMLC_CMD) -i $<
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/modules_with_mli.make
+endif
 
 clean::
 	rm -f *.cm[ioxa] *.o *.a *.cmxa *.annot

--- a/parsing_c/Makefile
+++ b/parsing_c/Makefile
@@ -131,12 +131,9 @@ locindiv:
 
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
-	$(OCAMLC_CMD) -c $<
-.mli.cmi:
-	$(OCAMLC_CMD) -c $<
-.ml.cmx:
-	$(OCAMLOPT_CMD) -c $<
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/modules_with_mli.make
+endif
 
 clean::
 	rm -f *.cm[ioxa] *.o *.a *.cmxa *.annot

--- a/parsing_cocci/Makefile
+++ b/parsing_cocci/Makefile
@@ -7,7 +7,8 @@ include ../Makefile.config
 -include ../Makefile.local
 endif
 
-TARGET=cocci_parser
+TARGET::=parsing_cocci
+TARGET_ALIAS::=cocci_parser
 
 OCAMLCFLAGS ?= -g
 OPTFLAGS ?= -g
@@ -16,7 +17,7 @@ LEXER_SOURCES = lexer_cocci.mll
 CLI_LEXER_SOURCES = lexer_cli.mll
 SCRIPT_LEXER_SOURCES = lexer_script.mll
 PARSER_SOURCES = parser_cocci_menhir.mly
-SOURCES = flag_parsing_cocci.ml ast_cocci.ml ast0_cocci.ml \
+SRC::=flag_parsing_cocci.ml ast_cocci.ml ast0_cocci.ml \
 pretty_print_cocci.ml visitor_ast0_types.ml \
 visitor_ast.ml visitor_ast0.ml ast0toast.ml unparse_ast0.ml unify_ast.ml \
 compute_lines.ml iso_pattern.ml comm_assoc.ml \
@@ -44,17 +45,18 @@ MENHIROMOD=menhirLib.cmx
 
 # The Caml compilers.
 OCAMLCFLAGS ?= -g -dtypes
-EXEC=$(TARGET).byte
-EXEC=$(TARGET)
-LIB=$(TARGET).cma
+EXEC::=$(TARGET_ALIAS).byte
+EXEC::=$(TARGET_ALIAS)
+LIB::=$(TARGET_ALIAS).cma
 OPTLIB=$(LIB:.cma=.cmxa)
 
 GENERATED= $(LEXER_SOURCES:.mll=.ml) \
 	   $(CLI_LEXER_SOURCES:.mll=.ml) $(SCRIPT_LEXER_SOURCES:.mll=.ml) \
 	   $(PARSER_SOURCES:.mly=.ml) $(PARSER_SOURCES:.mly=.mli)
-OBJS = $(SOURCES:.ml=.cmo)
+OBJS::=$(SRC:.ml=.cmo)
 OPTOBJS = $(OBJS:.cmo=.cmx)
-
+OCAMLC_CMD=$(OCAMLC) $(OCAMLCFLAGS) $(INCLUDES)
+OCAMLOPT_CMD=$(OCAMLOPT) $(OPTFLAGS) $(INCLUDES)
 
 all: $(LIB)
 local: $(EXEC)
@@ -63,33 +65,28 @@ all.opt:
 	@$(MAKE) $(OPTLIB) BUILD_OPT=yes
 
 $(LIB): $(GENERATED) $(OBJS)
-	$(OCAMLC) $(OCAMLCFLAGS) $(INCLUDES) -I $(MENHIRDIR) -a -o $(LIB) $(MENHIRMOD) $(OBJS)
+	$(OCAMLC_CMD) -I $(MENHIRDIR) -a -o $(LIB) $(MENHIRMOD) $(OBJS)
 
 
 $(OPTLIB): $(GENERATED) $(OPTOBJS)
-	$(OCAMLOPT) $(OPTFLAGS) $(INCLUDES) -I $(MENHIRDIR) -a -o $(OPTLIB) $(MENHIROMOD) $(OPTOBJS)
+	$(OCAMLOPT_CMD) -I $(MENHIRDIR) -a -o $(OPTLIB) $(MENHIROMOD) $(OPTOBJS)
 
 
 $(EXEC): $(OBJS) main.cmo $(LIBS)
-	$(OCAMLC) $(OCAMLCFLAGS) $(INCLUDES) -o $(EXEC) $(SYSLIBS) $(LIBS) $(OBJS) main.cmo
+	$(OCAMLC_CMD) -o $(EXEC) $(SYSLIBS) $(LIBS) $(OBJS) main.cmo
 
 clean::
 	rm -f $(LIB)
 	rm -f $(OPTLIB) $(LIB:.cma=.a)
-	rm -f $(TARGET)
+	rm -f $(TARGET_ALIAS)
 
 
 .SUFFIXES:
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
-	$(OCAMLC) $(OCAMLCFLAGS) $(INCLUDES) -c $<
-
-.mli.cmi:
-	$(OCAMLC) $(OCAMLCFLAGS) $(INCLUDES) -c $<
-
-.ml.cmx:
-	$(OCAMLOPT) $(OPTFLAGS) $(INCLUDES) -c $<
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/modules_with_mli.make
+endif
 
 $(LEXER_SOURCES:.mll=.ml) :	$(LEXER_SOURCES)
 	$(OCAMLLEX) $(LEXER_SOURCES)

--- a/popl/Makefile
+++ b/popl/Makefile
@@ -2,7 +2,7 @@
 # See copyright.txt in the Coccinelle source code for more information.
 # The Coccinelle source code can be obtained at http://coccinelle.lip6.fr
 
-#note: if you add a file (a .mli or .ml), dont forget to do a   make depend
+#note: if you add a file (a .mli or .ml), don't forget to do a make depend
 
 ifneq ($(MAKECMDGOALS),distclean)
 include ../Makefile.config
@@ -20,15 +20,15 @@ pretty_print_popl.ml popltoctl.ml popl.ml flag_popl.ml
 SYSLIBS=str.cma unix.cma
 LIBS=../commons/commons.cma ../globals/globals.cma
 
-INCLUDE_PATH = -I ../commons -I ../globals \
-	       -I ../ctl -I ../parsing_c -I ../parsing_cocci -I ../engine
+INCLUDES::= -I ../commons -I ../globals \
+            -I ../ctl -I ../parsing_c -I ../parsing_cocci -I ../engine
 
 #The Caml compilers.
 #for warning:  -w A
 #for profiling:  -p -inline 0   with OCAMLOPT
-OCAMLC_CMD=$(OCAMLC) $(OCAMLCFLAGS)
-OCAMLOPT_CMD=$(OCAMLOPT) $(OPTFLAGS)
-OCAMLDEP_CMD=$(OCAMLDEP)
+OCAMLC_CMD=$(OCAMLC) $(OCAMLCFLAGS) $(INCLUDES)
+OCAMLOPT_CMD=$(OCAMLOPT) $(OPTFLAGS) $(INCLUDES)
+OCAMLDEP_CMD=$(OCAMLDEP) $(INCLUDES)
 OCAMLMKTOP_CMD=$(OCAMLMKTOP) -g -custom
 
 LIB=$(TARGET).cma
@@ -62,15 +62,24 @@ clean::
 .SUFFIXES:
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
-	$(OCAMLC_CMD) $(INCLUDE_PATH) -c $<
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/common_rules.make
 
-.mli.cmi:
-	$(OCAMLC_CMD) $(INCLUDE_PATH) -c $<
+modules_with_mli::=\
+asttopopl \
+insert_befaft \
+insert_quantifiers \
+popl \
+popltoctl \
+pretty_print_popl
+include $(abs_top_srcdir)/rule_pair2.make
 
-.ml.cmx:
-	$(OCAMLOPT_CMD) $(INCLUDE_PATH) -c $<
+ast_popl.cmo: ast_popl.ml ../parsing_cocci/ast_cocci.cmi
+	$(OCAMLC_CMD) -c $<
 
+ast_popl.cmx: ast_popl.ml ../parsing_cocci/ast_cocci.cmi
+	$(OCAMLOPT_CMD) -c $<
+endif
 
 # clean rule for others files
 clean::
@@ -82,7 +91,7 @@ distclean: clean
 
 .PHONY: depend
 .depend depend:
-	$(OCAMLDEP_CMD) $(INCLUDE_PATH) *.mli *.ml > .depend
+	$(OCAMLDEP_CMD) *.mli *.ml > .depend
 
 ifneq ($(MAKECMDGOALS),clean)
 ifneq ($(MAKECMDGOALS),distclean)

--- a/popl09/Makefile
+++ b/popl09/Makefile
@@ -2,7 +2,7 @@
 # See copyright.txt in the Coccinelle source code for more information.
 # The Coccinelle source code can be obtained at http://coccinelle.lip6.fr
 
-#note: if you add a file (a .mli or .ml), dont forget to do a   make depend
+#note: if you add a file (a .mli or .ml), don't forget to do a make depend
 
 ifneq ($(MAKECMDGOALS),distclean)
 include ../Makefile.config
@@ -61,15 +61,17 @@ clean::
 .SUFFIXES:
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
-	$(OCAMLC_CMD) -c $<
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/common_rules.make
 
-.mli.cmi:
-	$(OCAMLC_CMD) -c $<
-
-.ml.cmx:
-	$(OCAMLOPT_CMD) -c $<
-
+modules_with_mli::=\
+asttopopl \
+insert_quantifiers \
+popl \
+popltoctl \
+pretty_print_popl
+include $(abs_top_srcdir)/rule_pair2.make
+endif
 
 # clean rule for others files
 clean::

--- a/python/Makefile
+++ b/python/Makefile
@@ -107,15 +107,12 @@ distclean::
 .SUFFIXES:
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
-	$(OCAMLC_CMD) -c $<
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/common_rules.make
 
-.mli.cmi:
-	$(OCAMLC_CMD) -c $<
-
-.ml.cmx:
-	$(OCAMLOPT_CMD) -c $<
-
+modules_with_mli::=pycocci_aux pycocci
+include $(abs_top_srcdir)/rule_pair2.make
+endif
 
 # clean rule for others files
 clean::

--- a/rule_pair.make
+++ b/rule_pair.make
@@ -1,0 +1,23 @@
+# This file is part of Coccinelle, licensed under the terms of the GPL v2.
+# See copyright.txt in the Coccinelle source code for more information.
+# The Coccinelle source code can be obtained at http://coccinelle.lip6.fr
+
+define rule_pair =
+x_rule_pair_m::=$$(basename $(1))
+
+ifeq ($$(use_separate_build_directory),)
+x_rule_pair_i::=
+else
+x_rule_pair_i::=$$(abs_top_builddir)/$$(TARGET)/
+endif
+
+x_rule_pair_i+=$$(x_rule_pair_m).cmi
+
+$$(x_rule_pair_m).cmo: $(1) $$(x_rule_pair_i)
+	$$(OCAMLC_CMD) -c $$<
+
+$$(x_rule_pair_m).cmx: $(1) $$(x_rule_pair_i)
+	$$(OCAMLOPT_CMD) -c $$<
+endef
+
+$(foreach x,$(SRC_with_mli),$(eval $(call rule_pair,$(x))))

--- a/rule_pair2.make
+++ b/rule_pair2.make
@@ -1,0 +1,9 @@
+# This file is part of Coccinelle, licensed under the terms of the GPL v2.
+# See copyright.txt in the Coccinelle source code for more information.
+# The Coccinelle source code can be obtained at http://coccinelle.lip6.fr
+
+$(addsuffix .cmo,$(modules_with_mli)): %.cmo: %.ml %.cmi
+	$(OCAMLC_CMD) -c $<
+
+$(addsuffix .cmx,$(modules_with_mli)): %.cmx: %.ml %.cmi
+	$(OCAMLOPT_CMD) -c $<

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -70,12 +70,9 @@ isoprof: process_isoprofile
 
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
-	$(OCAMLC_CMD) -c $<
-.mli.cmi:
-	$(OCAMLC_CMD) -c $<
-.ml.cmx:
-	$(OCAMLOPT_CMD) -c $<
+ifneq ($(strip $(abs_top_srcdir)),)
+include $(abs_top_srcdir)/common_rules.make
+endif
 
 clean::
 	rm -f *.cm[ioxa] *.o *.a *.cmxa *.annot


### PR DESCRIPTION
A bit of progress was achieved with one experiment for build script adjustments.
Unfortunately, [an error message](https://systeme.lip6.fr/pipermail/cocci/2017-June/004181.html "Replacing suffix rules in make scripts?") like the following from the program “GNU Make 4.2.1-1.7” was noticed then.

```sh
…
/usr/bin/ocamlopt.opt …
File "cocci.ml", line 1:
Error: Could not find the .cmi file for interface cocci.mli.
make[3]: *** [Makefile:533: cocci.cmx] Error 2
…
```

* It took then a while to realise how incomplete the dependency specifications still were which were used so far.
* This area is also [work in progress (as usual)](https://en.wikipedia.org/wiki/Work_in_process "Descriptions for work in progress"). Several places can be improved.

Some extra dependencies were integrated by inclusion of the make script “.depend” which was automatically generated by [the tool “ocamldep”](https://caml.inria.fr/pub/docs/manual-ocaml/depend.html "Dependency generator"). Further tests pointed places out despite of this detail where the build approach failed in a “special” software development configuration.
This approach can still fail occasionally because significant development efforts and attention are needed to [keep the desired build rules consistent](https://www.gnu.org/software/make/manual/html_node/Multiple-Rules.html "Multiple rules for one target").

* The affected make rules were also repeated in several scripts. They were moved to a separate script and included then from there.
* The relevance of compiled interface descriptions was increased by the adjustment of corresponding details. Some rules are also automatically generated by a script like “rule_pair.make” now. [The usage of static pattern rules](https://www.gnu.org/software/make/manual/html_node/Static-Usage.html "Syntax of static pattern rules") can also help to some degree.

I hope that these working software development results can become [another useful information source](https://www.gnu.org/philosophy/free-sw.html "Explanation for possibilities with free software") for general inspiration and [better clarification of remaining open issues](https://github.com/coccinelle/coccinelle/issues "Registered issues").
:crystal_ball: How would you like to integrate further ideas there?