### PR TITLE
Use ChangeLog date instead of build date

### DIFF
--- a/setup/cocci.m4
+++ b/setup/cocci.m4
@@ -222,11 +222,11 @@ AC_DEFUN([AC_COCCI_CONFVERSION],
   ])
 
   AS_IF([test -z "$CONFVERSION"],
-  [dnl  otherwise, take the current date
+  [dnl  otherwise, take the changelog date
     AC_PATH_TOOL([DATE],[date])
     AS_IF([test -n "$DATE"],
     [dnl
-      CONFVERSION=`$DATE "+%a, %d %b %Y %H:%M:%S %z"`
+      CONFVERSION=`$DATE -u -r changes.txt "+%a, %d %b %Y %H:%M:%S %z"`
     ])
   ])
 


### PR DESCRIPTION
Use ChangeLog date instead of build date
in order to make builds from release tarballs reproducible.
See https://reproducible-builds.org/ for why this is good.

Also use date -u to not depend on the packager's timezone.


Note: there is one remaining issue likely from pycaml embedding a /tmp/camlprimXXXXXX.c random string in spatch debug_str section but that can be solved independently of this one.