### PR TITLE
ocaml: include support for statement list AST

### DIFF
--- a/ocaml/yes_prepare_ocamlcocci.ml
+++ b/ocaml/yes_prepare_ocamlcocci.ml
@@ -114,7 +114,7 @@ let ast_rep_binding ctr = function
   | (Some nm,Ast.MetaFieldDecl _) -> print_match ctr nm "Field"
   | (Some nm,Ast.MetaFieldListDecl _) -> print_match ctr nm "FieldList"
   | (Some nm,Ast.MetaStmDecl _) -> print_match ctr nm "Stmt"
-  | (Some nm,Ast.MetaStmListDecl _) -> failwith ("not supported: "^nm)
+  | (Some nm,Ast.MetaStmListDecl _) -> print_match ctr nm "StmtList"
   | (Some nm,Ast.MetaFmtDecl _) -> print_match ctr nm "Fmt"
   | (Some nm,Ast.MetaFragListDecl _) -> print_match ctr nm "FragList"
   | (Some nm,Ast.MetaFuncDecl _) -> print_match ctr nm "Str"


### PR DESCRIPTION
Statement lists were not supported in the OCaml script feature that allows extracting the AST from the matched metavariable.
I couldn't see a good reason why it shouldn't.