### PR TITLE
Fixing typos

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -62,7 +62,7 @@ export CPPFLAGS=@CPPFLAGS@
 MKDIR_P=@MKDIR_P@
 
 # the default Make target
-# Can be overriden e.g. in Makefile.local
+# Can be overridden e.g. in Makefile.local
 TARGET_ALL=all-release
 EXTRA_OCAML_FLAGS=-unsafe
 TARGET_SPATCH=@MAKETARGET_SPATCH@

--- a/Makefile.libs
+++ b/Makefile.libs
@@ -8,7 +8,7 @@
 #
 # Template:
 # LOCAL_$lib     = modules to include when compiling $lib locally with bytecode ocaml
-# LOCALOPT_$lib  = moduels to include when compiling $lib locally with optimizing ocaml
+# LOCALOPT_$lib  = modules to include when compiling $lib locally with optimizing ocaml
 # GLOBAL_$lib    = modules to include when using $lib globally with bytecode ocaml
 # GLOBALOPT_$lib = modules to include when using $lib globally with optimizing ocaml
 # FLAGS_$lib     = extra flags to pass to optimizing ocaml when using $lib at link time

--- a/Makefile.release
+++ b/Makefile.release
@@ -40,7 +40,7 @@ ifndef OCAMLVERSION
 OCAMLVERSION=$(shell ocaml -version |perl -p -e 's/.*version (.*)/$$1/;')
 endif
 
-# can be overriden in the environment
+# can be overridden in the environment
 ifndef GIT
 GIT=git
 endif

--- a/changes.txt
+++ b/changes.txt
@@ -55,7 +55,7 @@
   curly-brackets can be omitted for a single item), regular expression
   (=~ "..." or !~ "..."), integer comparison (<=, <, >=, >) or scripts
   (:script:...). Constraints can be used in conjunctions (&&),
-  disjunctions (||) and can be negated (!)  and parenthesed.
+  disjunctions (||) and can be negated (!)  and parenthesized.
   Sub-expression constraints (<=) are still dealt separately and can
   only be used individually or in conjunction with other constraints
   (not under a disjunction or a negation). See tests/constraints.cocci
@@ -107,7 +107,7 @@
   considered.
 - Generalization of script constraints to allow reference to metavariables
   defined in the same rule, only when the constrained metavariable always
-  occurs in rule_elems that also mention any othe local metavariables
+  occurs in rule_elems that also mention any other local metavariables
   mentioned in the script constraint.  Referenced local variables must be
   declared before the constrained one.
 - Allow more variety in #pragmas
@@ -281,7 +281,7 @@ Rodriguez.
 - Safer handing of loops in ...
 * 1.0.0
 ** Language:
-- Add metavariables for matcing assignment and binary operators.
+- Add metavariables for matching assignment and binary operators.
 - Add ...... to match ... in C function declarations and definitions.
 - Addition of initializer list metavariables.  Thanks to Michael Stefaniuc
   for noticing the need for them.
@@ -596,7 +596,7 @@ Rodriguez.
 - Save virtual identifiers from the command line for use in finalize code.
 - Make ocaml file prefix name be just a constant string rather than being
   determined by the semantic patch file name, to avoid
-  incompatabilities between the semantic patch file name and what is
+  incompatibilities between the semantic patch file name and what is
   allowed for the names of ocaml modules.  Thanks to Markus Elfring for
   noticing the problem.
 - Improved use of parsing_hacks when an item of interest is preceded by
@@ -1288,7 +1288,7 @@ Rodriguez.
 ** first public release of the source code:
 
 ** Language:
- - embeded python scripting
+ - embedded python scripting
  - position
 
 ** Features

--- a/cocci.ml
+++ b/cocci.ml
@@ -722,7 +722,7 @@ let print_dependencies str local global dep =
  *   "a/b/c/x"
  *
  * update: if the include is inside a ifdef a put nothing. cf -test incl.
- * this is because we dont want code added inside ifdef.
+ * this is because we don't want code added inside ifdef.
  *)
 
 let compute_new_prefixes xs =

--- a/commons/common.ml
+++ b/commons/common.ml
@@ -75,7 +75,7 @@
  *  - pcre
  *  - sdl
  *
- * Many functions in this file were inspired by Haskell or Lisp librairies.
+ * Many functions in this file were inspired by Haskell or Lisp libraries.
  *)
 
 (*****************************************************************************)
@@ -714,7 +714,7 @@ let (example3: string -> bool -> unit) = fun s b ->
  *   _list_bool := (s,func):: (!_list_bool)
  *
  * I would like to do as a func that take 2 terms, and make an = over it
- * avoid to add this ugly fun (), but pb of type, cant do that :(
+ * avoid to add this ugly fun (), but pb of type, can't do that :(
  *)
 
 
@@ -780,14 +780,14 @@ let test_exn x s =
 (* Quickcheck like (sfl) *)
 (*****************************************************************************)
 
-(* Better than quickcheck, cos cant do a test_all_prop in haskell cos
+(* Better than quickcheck, cos can't do a test_all_prop in haskell cos
  * prop were functions, whereas here we have not prop_Unix x = ... but
  * laws "unit" ...
  *
  * How to do without overloading ? objet ? can pass a generator as a
  * parameter, mais lourd, prefer automatic inferring of the
  * generator? But at the same time quickcheck does not do better cos
- * we must explictly type the property. So between a
+ * we must explicitly type the property. So between a
  *    prop_unit:: [Int] -> [Int] -> bool ...
  *    prop_unit x = reverse [x] == [x]
  * and
@@ -1102,7 +1102,7 @@ let (+!>) refo f = refo := f !refo
 
 let ($)     f g x = g (f x)
 let compose f g x = f (g x)
-(* dont work :( let ( \B0 ) f g x = f(g(x)) *)
+(* don't work :( let ( \B0 ) f g x = f(g(x)) *)
 
 (* trick to have something similar to the   1 `max` 4   haskell infix notation.
    by Keisuke Nakano on the caml mailing list.
@@ -1305,7 +1305,7 @@ exception WrongFormat of string
 (* old: let _TODO () = failwith "TODO",  now via fix_caml with raise Todo *)
 
 let internal_error s = failwith ("internal error: "^s)
-let error_cant_have x = internal_error ("cant have this case: " ^(Dumper.dump x))
+let error_cant_have x = internal_error ("can't have this case: " ^(Dumper.dump x))
 let myassert cond = if cond then () else failwith "assert error"
 
 
@@ -1562,7 +1562,7 @@ let arg_parse2 l msg short_usage_fun =
 
 
 (* ---------------------------------------------------------------------- *)
-(* kind of unit testing framework, or toplevel like functionnality
+(* kind of unit testing framework, or toplevel like functionality
  * at shell command line. I realize than in fact It follows a current trend
  * to have a main cmdline program where can then select different actions,
  * as in cvs/hg/git where do  hg <action> <arguments>, and the shell even
@@ -2443,7 +2443,7 @@ let filename_without_leading_path prj_path s =
   then matched1 s
   else
     failwith
-      (spf "cant find filename_without_project_path: %s  %s" prj_path s)
+      (spf "can't find filename_without_project_path: %s  %s" prj_path s)
 
 let rec join_path dir path =
   match path with
@@ -4599,7 +4599,7 @@ let apply_assoc key f xs =
 let big_union_assoc f xs = xs +> map_assoc f +> fold_assoc union_set empty_set
 
 (* todo: pb normally can suppr fun l -> .... l but if do that, then strange type _a
- => assoc_map is strange too => equal dont work
+ => assoc_map is strange too => equal don't work
 *)
 let (assoc_reverse: (('a * 'b) list) -> (('b * 'a) list)) = fun l ->
   List.map (fun(x,y) -> (y,x)) l
@@ -5065,8 +5065,8 @@ let find_multi_treeref_with_parents_some f tree =
 (*****************************************************************************)
 (* todo: generalise to put in common (need 'edge (and 'c ?),
  * and take in param a display func, cos caml sux, no overloading of show :(
- * Simple impelemntation. Can do also matrix, or adjacent list, or pointer(ref)
- * todo: do some check (dont exist already, ...)
+ * Simple implementation. Can do also matrix, or adjacent list, or pointer(ref)
+ * todo: do some check (don't exist already, ...)
  *)
 
 type 'node graph = ('node set) * (('node * 'node) set)
@@ -5442,7 +5442,7 @@ let full_charpos_to_pos2 = fun filename ->
        let s = (input_line chan) in
        incr line;
 
-       (* '... +1 do'  cos input_line dont return the trailing \n *)
+       (* '... +1 do'  cos input_line don't return the trailing \n *)
        let slength = String.length s in
        for i = 0 to (slength - 1) + 1 do
          arr.(!charpos + i) <- (!line, i);
@@ -5645,7 +5645,7 @@ let print_score score =
 
 
 (*****************************************************************************)
-(* Scope managment (cocci) *)
+(* Scope management (cocci) *)
 (*****************************************************************************)
 
 (* could also make a function Common.make_scope_functions that return

--- a/commons/common.mli
+++ b/commons/common.mli
@@ -13,7 +13,7 @@
  * The variables that are called _init_xxx show the internal init
  * side effect of the module (like static var trick used in C/C++)
  *
- * Why not split the functionnalities of this file in different files ?
+ * Why not split the functionalities of this file in different files ?
  * Because when I write ocaml script I want simply to load one
  * file, common.ml, and that's it. Cf common_extra.ml for more on this.
  *)
@@ -323,7 +323,7 @@ val format_to_string : (unit -> unit) (* printer *) -> string
 
 (* works with _tab_level_print enabling to mix some calls to pp, pr2
  * and indent_do to sometimes use advanced indentation pretty printing
- * (with the pp* functions) and sometimes explicit and simple indendation
+ * (with the pp* functions) and sometimes explicit and simple indentation
  * printing (with pr* and indent_do) *)
 val adjust_pp_with_indent : (unit -> unit) -> unit
 val adjust_pp_with_indent_and_header : string -> (unit -> unit) -> unit
@@ -439,7 +439,7 @@ val acquire_file_lock : filename -> unit
 val release_file_lock : filename -> unit
 
 (*****************************************************************************)
-(* Error managment *)
+(* Error management *)
 (*****************************************************************************)
 exception Todo
 exception Impossible of int

--- a/commons/ograph_extended.ml
+++ b/commons/ograph_extended.ml
@@ -3,7 +3,7 @@
  *  -  node: index -> nodevalue
  *  -  arc: (index * index) * edgevalue
  *
- * invariant: key in pred is also in succ (completness) and value in
+ * invariant: key in pred is also in succ (completeness) and value in
  * either assoc is a key also.
  *
  * How ? matrix ? but no growing array :(

--- a/commons/readme.txt
+++ b/commons/readme.txt
@@ -1,7 +1,7 @@
 
 This directory builds a common.cma library and also optionally
 multiple commons_xxx.cma small libraries. The reason not to just build
-a single one is that some functionnalities require external libraries
+a single one is that some functionalities require external libraries
 (like Berkeley DB, MPI, etc) or special version of OCaml (like for the
 backtrace support) and I don't want to penalize the user by forcing
 him to install all those libs before being able to use some of my
@@ -22,7 +22,7 @@ the header and linker dependencies in Makefiles. A solution is
 to use cpp and pre-process many files that have such configuration
 issue. Another solution is to centralize all the cpp issue in one
 file, features.ml.cpp, that acts as a generic wrapper for other
-librairies and depending on the configuration actually call
+libraries and depending on the configuration actually call
 the external library or provide a fake empty services indicating
 that the service is not present.
 So you should have a ../configure that call cpp on features.ml.cpp

--- a/ctl/ctl_engine.ml
+++ b/ctl/ctl_engine.ml
@@ -476,7 +476,7 @@ let merge_subBy eqx (===) (>+<) sub sub' =
 ;;
 
 (* NOTE: functor *)
-(* How could we accomadate subterm constraints here??? *)
+(* How could we accommodate subterm constraints here??? *)
 let merge_sub sub sub' =
   merge_subBy SUB.eq_mvar SUB.eq_val SUB.merge_val sub sub'
 

--- a/debian/rules
+++ b/debian/rules
@@ -41,7 +41,7 @@ override_dh_auto_test:
 override_dh_auto_install:
 	$(MAKE) DESTDIR=$(CURDIR)/debian/coccinelle $(COCCI_FLAGS) install
 	$(MAKE) DESTDIR=$(CURDIR)/debian/coccinelle                install-bash
-	# install the wrapper script, i dont like upstreams one
+	# install the wrapper script, i don't like upstreams one
 	rm $(CURDIR)/debian/coccinelle/usr/bin/spatch*
 	install $(CURDIR)/debian/spatch $(CURDIR)/debian/coccinelle/usr/bin/
 	# move binary into /usr/lib/coccinelle

--- a/demos/demo_rule9/g_NCR5380.res
+++ b/demos/demo_rule9/g_NCR5380.res
@@ -541,7 +541,7 @@ int generic_NCR5380_biosparam(struct scsi_device *sdev,
  *	@dst: buffer to read into
  *	@len: buffer length
  *
- *	Perform a psuedo DMA mode read from an NCR53C400 or equivalent
+ *	Perform a pseudo DMA mode read from an NCR53C400 or equivalent
  *	controller
  */
  
@@ -625,7 +625,7 @@ static inline int NCR5380_pread(struct Scsi_Host *instance, unsigned char *dst, 
  *	@dst: buffer to read into
  *	@len: buffer length
  *
- *	Perform a psuedo DMA mode read from an NCR53C400 or equivalent
+ *	Perform a pseudo DMA mode read from an NCR53C400 or equivalent
  *	controller
  */
 

--- a/demos/demo_rule9/nsp_cs.c
+++ b/demos/demo_rule9/nsp_cs.c
@@ -621,7 +621,7 @@ static int nsp_reselected(Scsi_Cmnd *SCpnt, nsp_hw_data *data)
 }
 
 /*
- * count how many data transferd
+ * count how many data transferred
  */
 static int nsp_fifo_count(Scsi_Cmnd *SCpnt)
 {

--- a/demos/demo_rule9/nsp_cs.res
+++ b/demos/demo_rule9/nsp_cs.res
@@ -590,7 +590,7 @@ static int nsp_dataphase_bypass(Scsi_Cmnd *SCpnt, nsp_hw_data *data)
 
 	/*
 	 * XXX: NSP_QUIRK
-	 * data phase skip only occures in case of SCSI_LOW_READ
+	 * data phase skip only occurs in case of SCSI_LOW_READ
 	 */
 	DEBUG(0, " use bypass quirk\n");
 	SCpnt->SCp.phase = PH_DATA;
@@ -621,7 +621,7 @@ static int nsp_reselected(Scsi_Cmnd *SCpnt, nsp_hw_data *data)
 }
 
 /*
- * count how many data transferd
+ * count how many data transferred
  */
 static int nsp_fifo_count(Scsi_Cmnd *SCpnt)
 {
@@ -674,7 +674,7 @@ static void nsp_pio_read(Scsi_Cmnd *SCpnt, nsp_hw_data *data)
 
 		res = nsp_fifo_count(SCpnt) - ocount;
 		//DEBUG(0, " ptr=0x%p this=0x%x ocount=0x%x res=0x%x\n", SCpnt->SCp.ptr, SCpnt->SCp.this_residual, ocount, res);
-		if (res == 0) { /* if some data avilable ? */
+		if (res == 0) { /* if some data available ? */
 			if (stat == BUSPHASE_DATA_IN) { /* phase changed? */
 				//DEBUG(0, " wait for data this=%d\n", SCpnt->SCp.this_residual);
 				continue;
@@ -717,7 +717,7 @@ static void nsp_pio_read(Scsi_Cmnd *SCpnt, nsp_hw_data *data)
 		ocount			 += res;
 		//DEBUG(0, " ptr=0x%p this_residual=0x%x ocount=0x%x\n", SCpnt->SCp.ptr, SCpnt->SCp.this_residual, ocount);
 
-		/* go to next scatter list if availavle */
+		/* go to next scatter list if available */
 		if (SCpnt->SCp.this_residual	== 0 &&
 		    SCpnt->SCp.buffers_residual != 0 ) {
 			//DEBUG(0, " scatterlist next timeout=%d\n", time_out);
@@ -809,7 +809,7 @@ static void nsp_pio_write(Scsi_Cmnd *SCpnt, nsp_hw_data *data)
 		SCpnt->SCp.this_residual -= res;
 		ocount			 += res;
 
-		/* go to next scatter list if availavle */
+		/* go to next scatter list if available */
 		if (SCpnt->SCp.this_residual	== 0 &&
 		    SCpnt->SCp.buffers_residual != 0 ) {
 			//DEBUG(0, " scatterlist next\n");

--- a/demos/demo_rule9/scsiglue.res
+++ b/demos/demo_rule9/scsiglue.res
@@ -472,7 +472,7 @@ int usb_stor_scsiSense10to6( Scsi_Cmnd* the10 )
   outputBufferSize = *the10Locations.hdr.dataLengthLSB;
   outputBufferSize += USB_STOR_SCSI_SENSE_HDRSZ;
 
-  /* Check to see if we need to trucate the output */
+  /* Check to see if we need to truncate the output */
   if ( outputBufferSize > length )
     {
       printk( KERN_WARNING USB_STORAGE 
@@ -656,7 +656,7 @@ int usb_stor_scsiSense6to10( Scsi_Cmnd* the6 )
   outputBufferSize = *the6Locations.hdr.dataLength;
   outputBufferSize += USB_STOR_SCSI_SENSE_10_HDRSZ;
 
-  /* Check to see if we need to trucate the output */
+  /* Check to see if we need to truncate the output */
   if ( outputBufferSize > length )
     {
       printk( KERN_WARNING USB_STORAGE 

--- a/demos/janitorings/netdev_priv.cocci
+++ b/demos/janitorings/netdev_priv.cocci
@@ -65,7 +65,7 @@ expression E;
 // dev = alloc_netdev(sizeof(*x), ...)
 
 //>>> - alloc_irlandev
-// but dont pass the sizeof, so cant get the type T.
+// but don't pass the sizeof, so can't get the type T.
 
 //> alloc_orinocodev
 

--- a/demos/janitorings/static_initfunc.cocci
+++ b/demos/janitorings/static_initfunc.cocci
@@ -7,7 +7,7 @@
 // + static int __init func(void)
 //  { ... }
 
-// cant match on __init in cocci_vs_c
+// can't match on __init in cocci_vs_c
 //@@
 //identifier func;
 //@@
@@ -16,7 +16,7 @@
 //  { ... }
 
 
-// cant parse
+// can't parse
 //@@
 //identifier func;
 //@@

--- a/demos/ocaml/dbm.cocci
+++ b/demos/ocaml/dbm.cocci
@@ -24,7 +24,7 @@ yy << r.a;
 
 Dbm.add db y yy;
 if Str.string_match (Str.regexp "^foo") f 0
-then Printf.eprintf "Fct '%s' matchs \"^foo\"\n" f
+then Printf.eprintf "Fct '%s' matches \"^foo\"\n" f
 else Printf.eprintf "Fct '%s' does not match \"^foo\"\n" f
 
 @finalize:ocaml@

--- a/demos/ocaml/pg.cocci
+++ b/demos/ocaml/pg.cocci
@@ -22,7 +22,7 @@ yy << r.a;
 @@
 
 if Str.string_match (Str.regexp "^foo") f 0
-then Printf.eprintf "Fct '%s' matchs \"^foo\"\n" f
+then Printf.eprintf "Fct '%s' matches \"^foo\"\n" f
 else Printf.eprintf "Fct '%s' does not match \"^foo\"\n" f
 
 @finalize:ocaml@

--- a/demos/python_regexp.cocci
+++ b/demos/python_regexp.cocci
@@ -17,7 +17,7 @@ id << r_init.id;
 
 print "COCCI: Analyzing %s" % id
 if m.search(id) != None:
-	print "COCCI: %s matchs '_new$'" % id
+	print "COCCI: %s matches '_new$'" % id
 else:
 	print "COCCI: %s discarded" % id
 	cocci.include_match(False)

--- a/demos/unsigned.txt
+++ b/demos/unsigned.txt
@@ -53,7 +53,7 @@ W="$V\(\[$s$V$s\]\|\[$s$D$s\]\|\.$V\|->$V\)*"
 # catches it at once (less strict)
 w="\($V\|${V}\[$s$an_*${s}\]\|$V\.\|$V->\)\+"
 
-# seperators:
+# separators:
 s="[[:space:]]*";
 S="[[:space:]]\+"
 

--- a/docs/dev/README
+++ b/docs/dev/README
@@ -1,3 +1,3 @@
-This directry contains notes related to the developemnt of Coccinelle,
+This directory contains notes related to the developemnt of Coccinelle,
 such as things that are not yet working and should be made working
 improved, etc.

--- a/docs/pycocci.1
+++ b/docs/pycocci.1
@@ -99,7 +99,7 @@ their own, and provide an index reference number identifying each
 thread. Coccinelle would divide the amount of work required to be
 done and based on the index grant the thread a specific set of work.
 Some shell scripts could be used to help split the work out for you.
-\fBpycocci\fP was originally written to supercede these scripts and
+\fBpycocci\fP was originally written to supersede these scripts and
 use Python's multithreaded support, while also enabling some sensible
 arguments by default.
 

--- a/engine/check_reachability.ml
+++ b/engine/check_reachability.ml
@@ -31,7 +31,7 @@
   !(1v2) & EXE[!(1v2) U 47]
   The first !(1v2) is to discard immediately cases where the beginning and
   end of the path are the same.  Afterwards, it would only seem necessary to
-  serach up to the next occurrence of 47 (leaf), ensuring that there are not
+  search up to the next occurrence of 47 (leaf), ensuring that there are not
   1s or 2s (starting points) along the way.  Then the second 47 would be in
   the path, but possible not transformed.
  *)

--- a/engine/cocci_vs_c.ml
+++ b/engine/cocci_vs_c.ml
@@ -1607,7 +1607,7 @@ let rec (expression: (A.expression, Ast_c.expression) matcher) =
         (Printf.sprintf "not handling Opt/Multi on expr on line %d"
            (A.get_line e))
 
- (* Because of Exp cant put a raise Impossible; have to put a fail *)
+ (* Because of Exp can't put a raise Impossible; have to put a fail *)
 
  (* have not a counter part in coccinelle, for the moment *)
   | _, ((B.Sequence _,_),_)
@@ -4193,7 +4193,7 @@ and attribute_list attras attrbs =
         failwith "attribute: build dots: not possible" in
       let match_comma ea = None in
       let build_comma ia1 =
-        failwith "attribute list: build comma: not posible" in
+        failwith "attribute list: build comma: not possible" in
       let match_metalist ea = None in
       let build_metalist _ (ida,leninfo,keep,inherited) =
 	failwith "attribute list: build meta list: not possible" in

--- a/engine/pattern_c.ml
+++ b/engine/pattern_c.ml
@@ -55,7 +55,7 @@ module XMATCH = struct
    * Then by defining the correct combinators, can have quite pretty code (that
    * looks like the clean code of version0).
    *
-   * opti: return a lazy list of possible matchs ?
+   * opti: return a lazy list of possible matches ?
    *
    * version4: type tin = Lib_engine.metavars_binding
    *)

--- a/engine/transformation_c.ml
+++ b/engine/transformation_c.ml
@@ -251,10 +251,10 @@ module XTRANS = struct
 	   Some info ->
 	     failwith
 	       (Printf.sprintf
-		  "weird: dont have position info for the mcodekind in line %d column %d"
+		  "weird: don't have position info for the mcodekind in line %d column %d"
 		  info.Ast_cocci.line info.Ast_cocci.column)
 	 | None ->
-	     failwith "weird: dont have position info for the mcodekind"
+	     failwith "weird: don't have position info for the mcodekind"
 
     (* these remove constraints, at least those that contain pcre regexps,
        which cannot be compared (problem in the unparser) *)
@@ -693,7 +693,7 @@ module XTRANS = struct
      | Ast_cocci.CONTEXT (Ast_cocci.DontCarePos,_)
      | Ast_cocci.MINUS   (Ast_cocci.DontCarePos,_,_,_) ->
          Ast_cocci.DontCarePos
-     | _ -> failwith "weird: dont have position info for the mcodekind 2"
+     | _ -> failwith "weird: don't have position info for the mcodekind 2"
 
   let distrf (ii_of_x_f, distribute_mck_x_f) =
     fun ia x -> fun tin ->
@@ -704,7 +704,7 @@ module XTRANS = struct
       (* bug: check_pos mck max && check_pos mck min
        *
        * if do that then if have - f(...); and in C f(1,2); then we
-       * would get a "already tagged" because the '...' would sucess in
+       * would get a "already tagged" because the '...' would success in
        * transformaing both '1' and '1,2'. So being in the range is not
        * enough. We must be equal exactly to the range!
        *)
@@ -856,7 +856,7 @@ let (transform2: string (* rule name *) -> string list (* dropped_isos *) ->
       let node' = transform_re_node rule_elem node tin in
 
       (* assert that have done something. But with metaruleElem sometimes
-         dont modify fake nodes. So special case before on Fake nodes. *)
+         don't modify fake nodes. So special case before on Fake nodes. *)
       (match F.unwrap node with
       | F.Enter | F.Exit | F.ErrorExit
       | F.EndStatement _ | F.CaseNode _

--- a/enter.ml
+++ b/enter.ml
@@ -275,7 +275,7 @@ let print_version () =
   Printf.printf "Flags passed to the configure script: %s\n" flags;
   Printf.printf "OCaml scripting support: %s\n" withocaml;
   Printf.printf "Python scripting support: %s\n" withpython;
-  Printf.printf "Syntax of regular expresssions: %s\n" whichregexp;
+  Printf.printf "Syntax of regular expressions: %s\n" whichregexp;
   exit 0
 
 let short_options = [
@@ -613,7 +613,7 @@ let other_options = [
 
 
     "--disallow-nested-exps", Arg.Set Flag_matcher.disallow_nested_exps,
-       " disallow an expresion pattern from matching a term and its subterm";
+       " disallow an expression pattern from matching a term and its subterm";
     "--disable-worth-trying-opt", Arg.Clear Flag.worth_trying_opt,
     "   run the semantic patch even if the C file contains no relevant tokens";
     "--selected-only", Arg.Set FC.selected_only, "  only show selected files";

--- a/install.txt
+++ b/install.txt
@@ -98,7 +98,7 @@ needed for the compilation of ocaml scripts.
  by default in the directory pointed by
    pkg-config --variable=completionsdir bash-completion
  if available, or $datarootdir/bash-completion/completions otherwise.
- The directory can be overriden by passing --with-bash-completion=$DIR
+ The directory can be overridden by passing --with-bash-completion=$DIR
  to ./configure.
  The option --without-bash-completion disables the script installation.
 
@@ -111,7 +111,7 @@ needed for the compilation of ocaml scripts.
 
  - Basic shell commands:
    - ls, cat, cp, mv, rm, grep, mkdir, find
- - Developper tool: diff
+ - Developer tool: diff
 
 
  ** Optional runtime dependencies **

--- a/parsing_c/ast_c.ml
+++ b/parsing_c/ast_c.ml
@@ -1200,7 +1200,7 @@ let al_comments keep_comments x =
 	 supposed to, if this information is taken into account.  Actually,
 	 we only want this information for + code.  If we just put l here,
 	 then lots of tests fail, so it seems that metavariables are being
-	 matched agains, and not just used for + *)
+	 matched again, and not just used for + *)
       let rec loop = function
 	  [] -> []
 	| ((Token_c.TCommentNewline,_) as x)::

--- a/parsing_c/control_flow_c.ml
+++ b/parsing_c/control_flow_c.ml
@@ -23,7 +23,7 @@ open Ast_c
  *
  *  - We need later to go back from flow to original ast, because we are
  *    doing a refactoring tool, so different context. So we have to add
- *    some nodes for '{' or '}' or goto that normally disapear in a CFG.
+ *    some nodes for '{' or '}' or goto that normally disappear in a CFG.
  *    We must keep those entities, in the same way that we must keep the parens
  *    (ParenExpr, ParenType) in the Ast_c during parsing.
  *
@@ -47,7 +47,7 @@ open Ast_c
  *
  *
  *  - The CTL engine needs more information than just the CFG, and we use
- *    tricks to encode those informations in the nodes:
+ *    tricks to encode those information in the nodes:
  *
  *       - We have some TrueNode, FalseNode to know in what branch we are.
  *         Normally we could achieve this by putting this information in the

--- a/parsing_c/control_flow_c_build.ml
+++ b/parsing_c/control_flow_c_build.ml
@@ -251,8 +251,8 @@ let insert_all_braces xs starti nodety str =
  * ce label. De meme, meme le cas simple ou la derniere instruction
  * c'est un return, alors ca va generer un DeadCode :(
  *
- * So make a first pass where dont launch exn at all. Create nodes,
- * if starti is None then dont add arc. Then make a second pass that
+ * So make a first pass where don't launch exn at all. Create nodes,
+ * if starti is None then don't add arc. Then make a second pass that
  * just checks that all nodes (except enter) have predecessors.
  * So make starti an option too. So type is now
  *
@@ -549,7 +549,7 @@ let rec aux_statement : (nodei option * xinfo) -> statement -> nodei option =
               *   cf tests-bis/switch_no_body.c
               * but I don't think it's worthwhile to handle
               * such pathological and rare case. Not worth
-              * the complexity. Safe to assume a coumpound.
+              * the complexity. Safe to assume a compound.
               *)
              raise (Error (WeirdSwitch (pinfo_of_ii [i1])))
        in
@@ -1649,7 +1649,7 @@ let report_error error =
     match error with
     | DeadCode          infoopt ->
 	(match infoopt with
-	| None -> pr2 "FLOW: deadcode detected, but cant trace back the place"
+	| None -> pr2 "FLOW: deadcode detected, but can't trace back the place"
 	| Some info ->
 	    pr2 ("FLOW: deadcode detected: " ^ error_from_info info))
     | CaseNoSwitch      info ->
@@ -1662,7 +1662,7 @@ let report_error error =
     | NoEnclosingLoop   (info) ->
 	pr2 ("FLOW: can't find enclosing loop: " ^ error_from_info info)
     | GotoCantFindLabel (s, info) ->
-	pr2 ("FLOW: cant jump to " ^ s ^ ": because we can't find this label")
+	pr2 ("FLOW: can't jump to " ^ s ^ ": because we can't find this label")
     | NoExit info ->
 	pr2 ("FLOW: can't find exit or error exit: " ^ error_from_info info)
     | DuplicatedLabel s ->

--- a/parsing_c/cpp_analysis_c.ml
+++ b/parsing_c/cpp_analysis_c.ml
@@ -230,7 +230,7 @@ let (macro_expand:
     | Cpp_token_c.DefineHint _ ->
         body
     | Cpp_token_c.DefineBody xs ->
-        (* bugfix: we dont want to evalute the x ## b at this moment.
+        (* bugfix: we don't want to evaluate the x ## b at this moment.
          * so can not use fix_tokens_cpp in the same we use it
          * to parse C code.
         let xs' =

--- a/parsing_c/includes.mli
+++ b/parsing_c/includes.mli
@@ -41,7 +41,7 @@ val should_parse : parsing_style -> string -> Ast_c.inc_file -> bool
 
 val resolve : string -> parsing_style -> Ast_c.inc_file -> string option
 (**
- * [reslove f opt inc] determines whether [inc] included by [f]
+ * [resolve f opt inc] determines whether [inc] included by [f]
  * exists and should be parsed according to [opt].
  * If so, returns its name. Returns [None] otherwise.
  *)

--- a/parsing_c/lexer_parser.ml
+++ b/parsing_c/lexer_parser.ml
@@ -29,7 +29,7 @@ open Common
  * Why parse_typedef_fix2 ? Cos when introduce new variable, for
  * instance when declare parameters for a function such as int var_t,
  * then the var_t must not be lexed as a typedef, so we must disable
- * temporaly the typedef mechanism to allow variable with same name as
+ * temporary the typedef mechanism to allow variable with same name as
  * a typedef. *)
 
 (* parse_typedef_fix *)

--- a/parsing_c/parse_c.ml
+++ b/parsing_c/parse_c.ml
@@ -635,7 +635,7 @@ let max_pass = 4
 let get_one_elem ~pass tr =
 
   if not (LP.is_enabled_typedef()) && !Flag_parsing_c.debug_typedef
-  then pr2_err "TYPEDEF:_handle_typedef=false. Not normal if dont come from exn";
+  then pr2_err "TYPEDEF:_handle_typedef=false. Not normal if don't come from exn";
 
   (* normally have to do that only when come from an exception in which
    * case the dt() may not have been done
@@ -700,7 +700,7 @@ let candidate_macros_in_passed2 ~defs passed  =
 
   passed +> List.iter (function
   | Parser_c.TIdent (s,_)
-   (* bugfix: may have to undo some infered things *)
+   (* bugfix: may have to undo some inferred things *)
   | Parser_c.TMacroIterator (s,_)
   | Parser_c.TypedefIdent (s,_)
     ->
@@ -722,7 +722,7 @@ let candidate_macros_in_passed2 ~defs passed  =
   else !res
 
 let candidate_macros_in_passed ~defs b =
-  Common.profile_code "MACRO managment" (fun () ->
+  Common.profile_code "MACRO management" (fun () ->
     candidate_macros_in_passed2 ~defs b)
 
 
@@ -772,7 +772,7 @@ let find_optional_macro_to_expand2 ~defs pos toks =
     (!tokens2 +> Common.acc_map (fun x -> x.TV.tok))
   *)
 let find_optional_macro_to_expand ~defs pos a =
-    Common.profile_code "MACRO managment" (fun () ->
+    Common.profile_code "MACRO management" (fun () ->
       find_optional_macro_to_expand2 ~defs pos a)
 
 (*****************************************************************************)

--- a/parsing_c/parser_c.mly
+++ b/parsing_c/parser_c.mly
@@ -186,7 +186,7 @@ let (fixDeclSpecForDecl: decl -> (fullType * (storage wrap)))  = function
      raise (Semantic ("long, short valid only for int or float", fake_pi))
 
      (* if do short uint i, then gcc say parse error, strange ? it is
-      * not a parse error, it is just that we dont allow with typedef
+      * not a parse error, it is just that we don't allow with typedef
       * either short/long or signed/unsigned. In fact, with
       * parse_typedef_fix2 (with et() and dt()) now I say too parse
       * error so this code is executed only when do short struct
@@ -234,9 +234,9 @@ let fixDeclSpecForFuncDef x =
  * in func DEFINITION not in funct DECLARATION) We must have a name.
  * This function ensure that we give only parameterTypeDecl with well
  * formed Classic constructor todo?: do we accept other declaration
- * in ? so I must add them to the compound of the deffunc. I dont
+ * in ? so I must add them to the compound of the deffunc. I don't
  * have to handle typedef pb here cos C forbid to do VF f { ... }
- * with VF a typedef of func cos here we dont see the name of the
+ * with VF a typedef of func cos here we don't see the name of the
  * argument (in the typedef)
  *)
 let (fixOldCDecl: fullType -> fullType) = fun ty ->
@@ -271,7 +271,7 @@ let (fixOldCDecl: fullType -> fullType) = fun ty ->
         (* todo? can we declare prototype in the decl or structdef,
            ... => length <> but good kan meme *)
   | _ ->
-      (* gcc say parse error but dont see why *)
+      (* gcc say parse error but don't see why *)
       raise (Semantic ("seems this is not a function", fake_pi))
 
 
@@ -294,14 +294,14 @@ let fixFunc (typ, compound, old_style_opt) =
           (match Ast_c.unwrap_typeC ty2 with
           | BaseType Void ->  ()
           | _ ->
-                (* failwith "internal errror: fixOldCDecl not good" *)
+                (* failwith "internal error: fixOldCDecl not good" *)
               ()
           )
       | params ->
           params +> List.iter (function
           | ({p_namei = Some s}, _) -> ()
 	  | _ -> ()
-                (* failwith "internal errror: fixOldCDecl not good" *)
+                (* failwith "internal error: fixOldCDecl not good" *)
           )
       );
       (* bugfix: cf tests_c/function_pointer4.c.
@@ -344,7 +344,7 @@ let fixFunc (typ, compound, old_style_opt) =
   | _ ->
       raise
         (Semantic
-            ("you are trying to do a function definition but you dont give " ^
+            ("you are trying to do a function definition but you don't give " ^
              "any parameter", fake_pi))
 
 
@@ -371,7 +371,7 @@ let fix_add_params_ident x =
           (match Ast_c.unwrap_typeC ty2 with
           | BaseType Void -> ()
           | _ ->
-              (* failwith "internal errror: fixOldCDecl not good" *)
+              (* failwith "internal error: fixOldCDecl not good" *)
               ()
           )
       | params ->
@@ -380,7 +380,7 @@ let fix_add_params_ident x =
               LP.add_ident (Ast_c.str_of_name s)
 	  | _ ->
               ()
-                (* failwith "internal errror: fixOldCDecl not good" *)
+                (* failwith "internal error: fixOldCDecl not good" *)
           )
       )
   | _ -> ()
@@ -548,7 +548,7 @@ let postfakeInfo pii  =
 /*(*---------------*)*/
 
 
-/*(* used only in lexer_c, then transformed in comment or splitted in tokens *)*/
+/*(* used only in lexer_c, then transformed in comment or split in tokens *)*/
 %token <(string * string * bool ref * Ast_c.info)> TInclude
 
 /*(* tokens coming from above, generated in parse_c from TInclude, etc *)*/
@@ -1263,7 +1263,7 @@ type_spec2:
      { Right3 (Decimal($3,None)), [$1;$2;$4] }
 
  /*
- (* parse_typedef_fix1: cant put: TIdent {} cos it make the grammar
+ (* parse_typedef_fix1: can't put: TIdent {} cos it make the grammar
   * ambiguous, generates lots of conflicts => we must
   * use some tricks: we make the lexer and parser cooperate, cf lexerParser.ml.
   *
@@ -1480,7 +1480,7 @@ abstract_declaratorp:
 /*(*-----------------------------------------------------------------------*)*/
 
 /*(* for struct and also typename *)*/
-/*(* cant put decl_spec cos no storage is allowed for field struct *)*/
+/*(* can't put decl_spec cos no storage is allowed for field struct *)*/
 spec_qualif_list2:
  | type_spec                    { addTypeD ($1, nullDecl) }
  | type_qualif                  { {nullDecl with qualifD = (fst $1,[snd $1])}}
@@ -1774,14 +1774,14 @@ field_declaration:
      {
        let (returnType,storage) = fixDeclSpecForDecl $1 in
        if fst (unwrap storage) <> NoSto
-       then internal_error "parsing dont allow this";
+       then internal_error "parsing don't allow this";
 
        let iistart = Ast_c.fakeInfo () in (* for parallelism with DeclList *)
        FieldDeclList ($2 +> (List.map (fun (f, iivirg) ->
          f returnType, iivirg))
                          ,[$3;iistart])
-         (* dont need to check if typedef or func initialised cos
-          * grammar dont allow typedef nor initialiser in struct
+         (* don't need to check if typedef or func initialised cos
+          * grammar don't allow typedef nor initialiser in struct
           *)
      }
 
@@ -1790,7 +1790,7 @@ field_declaration:
        (* gccext: allow empty elements if it is a structdef or enumdef *)
        let (returnType,storage) = fixDeclSpecForDecl $1 in
        if fst (unwrap storage) <> NoSto
-       then internal_error "parsing dont allow this";
+       then internal_error "parsing don't allow this";
 
        let iistart = Ast_c.fakeInfo () in (* for parallelism with DeclList *)
        FieldDeclList ([(Simple (None, returnType)) , []], [$2;iistart])
@@ -2116,7 +2116,7 @@ cpp_ifdef_directive:
 /*(* cppext: *)*/
 cpp_other:
  /*(* no conflict ? no need for a TMacroTop ? apparently not as at toplevel
-    * the rule are slightly different, they cant be statement and so expr
+    * the rule are slightly different, they can't be statement and so expr
     * at the top, only decl or function definition.
     *)*/
  | identifier TOPar argument_list TCPar TPtVirg

--- a/parsing_c/parsing_hacks.ml
+++ b/parsing_c/parsing_hacks.ml
@@ -46,7 +46,7 @@ let msg_gen cond is_known printer s =
       if not (is_known s)
       then printer s
 
-(* In the following, there are some harcoded names of types or macros
+(* In the following, there are some hardcoded names of types or macros
  * but they are not used by our heuristics! They are just here to
  * enable to detect false positive by printing only the typedef/macros
  * that we don't know yet. If we print everything, then we can easily
@@ -627,7 +627,7 @@ let rec comment_until_defeol xs =
   match xs with
   | [] ->
       (* job not done in Cpp_token_c.define_parse ? *)
-      failwith "cant find end of define token TDefEOL"
+      failwith "can't find end of define token TDefEOL"
   | x::xs ->
       (match x with
       | Parser_c.TDefEOL i ->

--- a/parsing_c/parsing_hacks.mli
+++ b/parsing_c/parsing_hacks.mli
@@ -48,13 +48,13 @@ val filter_cpp_stuff :
 val insert_virtual_positions:
   Parser_c.token list -> Parser_c.token list
 
-(* mark suppported undisciplined uses of #ifdef *)
+(* mark supported undisciplined uses of #ifdef *)
 val fix_tokens_ifdef : Parser_c.token list -> Parser_c.token list
 
 (* expand format strings *)
 val fix_tokens_strings : Parser_c.token list -> Parser_c.token list
 
-(* will among other things interally call cpp_token_c to macro
+(* will among other things internally call cpp_token_c to macro
  * expand some macros *)
 val fix_tokens_cpp :
   macro_defs:(string, Cpp_token_c.define_def) Hashtbl.t ->

--- a/parsing_c/unparse_c.ml
+++ b/parsing_c/unparse_c.ml
@@ -1427,7 +1427,7 @@ this point.  The cases are as follows:
 1. Comma then space.
 2. Comma then newline.
 3. Comma then something else.
-4. Newline wth no preceding comma.
+4. Newline with no preceding comma.
 5. Start or end token, ie = ( ) { }.
 6. Anything else.
 
@@ -1755,7 +1755,7 @@ type info =
   | PlusNL of int (* depthplus *) * int (* inparen *)
   | Other of int | Drop | Unindent | Unindent1
   | Label (* label is for a newline that should not be taken into account
-	     to compute indentation; it might be befor a label, a #, or
+	     to compute indentation; it might be before a label, a #, or
 	     just an empty line *)
 
 let print_info l =

--- a/parsing_c/visitor_c.ml
+++ b/parsing_c/visitor_c.ml
@@ -1295,7 +1295,7 @@ and vk_statement_s = fun bigf st ->
 		  ExprStatement x1 -> ForExp (x1,i1')
 		| _ ->
 		    failwith
-		      "cant be here if iterator keep ExprStatement as is")
+		      "can't be here if iterator keep ExprStatement as is")
 	    | ForDecl decl -> ForDecl (vk_decl_s bigf decl) in
           let e2opt' = statf (mk_st (ExprStatement (e2opt)) i2) in
           let e3opt' = statf (mk_st (ExprStatement (e3opt)) i3) in
@@ -1309,7 +1309,7 @@ and vk_statement_s = fun bigf st ->
           | ((ExprStatement x2), ((ExprStatement x3))) ->
               Iteration (For (first, (x2,i2'), (x3,i3'), statf st))
 
-          | x -> failwith "cant be here if iterator keep ExprStatement as is"
+          | x -> failwith "can't be here if iterator keep ExprStatement as is"
          )
 
       | Iteration  (MacroIteration (s, es, st)) ->
@@ -1498,7 +1498,7 @@ and vk_onedecl_opt_s process_type bigf {v_namei = var;
 	  Ast_c.ConstrInit((init, List.map (vk_info_s bigf) ii)))
         ));
      v_type = if process_type then vk_type_s bigf t else t;
-    (* !!! dont go in semantic related stuff !!! *)
+    (* !!! don't go in semantic related stuff !!! *)
      v_type_bis = tbis;
      v_storage = sto;
      v_local = local;

--- a/parsing_cocci/adjust_pragmas.ml
+++ b/parsing_cocci/adjust_pragmas.ml
@@ -5,7 +5,7 @@
  *)
 
 (* Find a directive or comment at the end of a statement.  Things with aft
-given None, because they can accomodate their own directives or comments *)
+given None, because they can accommodate their own directives or comments *)
 
 module Ast0 = Ast0_cocci
 module Ast = Ast_cocci

--- a/parsing_cocci/free_vars.ml
+++ b/parsing_cocci/free_vars.ml
@@ -6,7 +6,7 @@
 
 (* For each rule return the list of variables that are used after it.
 Also augment various parts of each rule with unitary, inherited, and freshness
-informations *)
+information *)
 
 (* metavar decls should be better integrated into computations of free
 variables in plus code *)

--- a/parsing_cocci/free_vars.mli
+++ b/parsing_cocci/free_vars.mli
@@ -9,7 +9,7 @@ bindings.  These are combined in ctlcocciintegration, ie after the CTL
 generation. *)
 
 val free_vars : Ast_cocci.rule_with_metavars list ->
-  string list (* droped rules *) ->
+  string list (* dropped rules *) ->
   (Ast_cocci.metavar list list) * (Ast_cocci.rule list) *
     (((Ast_cocci.meta_name list) list) list) (*fvs of the rule*) *
     (((Ast_cocci.meta_name list * Ast_cocci.meta_name list)

--- a/parsing_cocci/get_constants2.ml
+++ b/parsing_cocci/get_constants2.ml
@@ -710,7 +710,7 @@ matched in a later one, we want to include files that originally contain
 the thing, so no point to keep track of what is added by earlier rules.
 The situation is something like a -> b v (b & c).  We don't actually need
 both b and c, but if we don't have b, then the only way that we can get it is
-fro the first rule matching, in which case the formula is already true. *)
+for the first rule matching, in which case the formula is already true. *)
 let rule_fn nm tls env neg_pos =
   (* tls seems like it is supposed to relate to multiple minirules.  If we
      were to actually allow that, then the following could be inefficient,

--- a/parsing_cocci/iso_pattern.ml
+++ b/parsing_cocci/iso_pattern.ml
@@ -2628,7 +2628,7 @@ let transform_expr (metavars,alts,name) e =
   in
   match alts with
     (Ast0.ExprTag(_)::r)::rs ->
-      (* hack to accomodate ToTestExpression case, where the first pattern is
+      (* hack to accommodate ToTestExpression case, where the first pattern is
 	 a normal expression, but the others are test expressions *)
       let others = r @ (List.concat rs) in
       let is_test = function Ast0.TestExprTag(_) -> true | _ -> false in

--- a/parsing_cocci/parse_aux.ml
+++ b/parsing_cocci/parse_aux.ml
@@ -752,7 +752,7 @@ let parse_middle middle clt =
 	    rres @ (loop (chars + (String.length r) + 1) rs) in
       first @ (loop chars rest)
 
-(* This doen't allow a newline in the middle of a string except at a %,
+(* This doesn't allow a newline in the middle of a string except at a %,
 perhaps not ideal *)
 let check_no_duplicates l =
   let rec loop = function

--- a/parsing_cocci/parse_cocci.ml
+++ b/parsing_cocci/parse_cocci.ml
@@ -2412,7 +2412,7 @@ let parse file =
 		  [] ->
 		    Ast0.InitialScriptRule(name,language,deps,mvs,pos,data)
 		| _ ->
-		    failwith "new metavariables not allowed in initalize") in
+		    failwith "new metavariables not allowed in initialize") in
 
 	  let parse_fscript_rule =
 	    parse_any_script_rule PC.script_meta_virt_nofresh_main

--- a/parsing_cocci/parser_cocci_menhir.mly
+++ b/parsing_cocci/parser_cocci_menhir.mly
@@ -1300,7 +1300,7 @@ includes:
 		 Ast0.wrap
 		   (Ast0.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast.CONST,
 				  pure,None))
-	     | _ -> failwith "length not allowed for include arugment")) }
+	     | _ -> failwith "length not allowed for include argument")) }
 
 | TUndef TLineEnd
     { let (clt,ident) = $1 in

--- a/popl/Makefile
+++ b/popl/Makefile
@@ -2,7 +2,7 @@
 # See copyright.txt in the Coccinelle source code for more information.
 # The Coccinelle source code can be obtained at http://coccinelle.lip6.fr
 
-#note: if you add a file (a .mli or .ml), dont forget to do a   make depend
+#note: if you add a file (a .mli or .ml), don't forget to do a   make depend
 
 ifneq ($(MAKECMDGOALS),distclean)
 include ../Makefile.config

--- a/python/coccilib/coccigui/vimcom.py
+++ b/python/coccilib/coccigui/vimcom.py
@@ -290,7 +290,7 @@ class communication_window(gtk.Window):
 
         Note: Vim does not actually unregister itself with the root window on
         dying, so the presence of a server in the root window list is no
-        gurantee that it is alive.
+        guarantee that it is alive.
 
         @return: servers
         @rtype servers: dict of ("server", "window id") key, value
@@ -311,12 +311,12 @@ class communication_window(gtk.Window):
                     # Set the value in the results dict, remembering to convert
                     # the window id to a long int.
                     servers[name_id[1]] = long(int(name_id[0], 16))
-        # return the list of resuts
+        # return the list of results
         return servers
 
     def get_shell_serverlist(self):
         """
-        DEPRACATED: WE NEVER NEED A SERVERLIST
+        DEPRECATED: WE NEVER NEED A SERVERLIST
         (This is here for educative purposes)
 
         Get the server list by starting console Vim on a Pipe.
@@ -332,13 +332,13 @@ class communication_window(gtk.Window):
  
     def get_hidden_serverlist(self, callbackfunc):
         """
-        DEPRACATED: WE NEVER NEED A SERVERLIST
+        DEPRECATED: WE NEVER NEED A SERVERLIST
         (This is here for educative purposes)
 
         Get the serverlist from the hidden Vim instance and call the callback
         function with the results.
 
-        This method checks first whther the Vim instance is alive, and then
+        This method checks first whether the Vim instance is alive, and then
         evaluates the serverlist() function remotely in it, with a local call
         back function which parses the result and calls the user-provided
         callback function.
@@ -468,7 +468,7 @@ class communication_window(gtk.Window):
  
     def parse_message(self, message):
         """
-        Parse a received message and return the message atributes as a
+        Parse a received message and return the message attributes as a
         dictionary.
         """
         messageattrs = {}

--- a/scripts/extract_c_and_res.pl
+++ b/scripts/extract_c_and_res.pl
@@ -223,7 +223,7 @@ foreach my $line (@headers) {
 foreach my $h (keys %{$hfiles}) {
   my ($base) = `basename $h`;
   chomp $base;
-  pr2 "processing additionnal header file: $h $base";
+  pr2 "processing additional header file: $h $base";
 
   if(-e "$target_dir/$base") {
     pr2 "-------------------------------------";

--- a/scripts/setlocalversion
+++ b/scripts/setlocalversion
@@ -43,7 +43,7 @@
 # If you do that, consider also using another PGP subkey for annotating
 # releases as deprecated.
 #
-# Set to emtpy variable if you use properly signed tags. You should do this!
+# Set to empty variable if you use properly signed tags. You should do this!
 TAGS="--tags"
 
 srctree=.

--- a/scripts/stat_directory_complete.pl
+++ b/scripts/stat_directory_complete.pl
@@ -101,7 +101,7 @@ $nbfiles = scalar(@cfiles);
 map {
   my ($linefile) = `wc -l $_`;
   chomp $linefile;
-  die "wierd wc output" unless $linefile =~ /^(\d+) /;
+  die "weird wc output" unless $linefile =~ /^(\d+) /;
   $sumlinefiles += $1;
   mylog "filesize $_ $1";
 } @cfiles;
@@ -227,7 +227,7 @@ if(-e "gitinfo") {
 
 
 foreach my $c (@cfiles) {
-  die "wierd: $c, with $spfile" unless ($c =~ /(.*)\.c$/);
+  die "weird: $c, with $spfile" unless ($c =~ /(.*)\.c$/);
   my $base = $1;
   my $bef = "$base.c";
   my $aft = "$base.res";

--- a/setup/fake-subst.sh
+++ b/setup/fake-subst.sh
@@ -107,12 +107,12 @@ checkpcre() {
   test -f /usr/include/pcre.h
 }
 
-# interate through pattern-response pairs
+# iterate through pattern-response pairs
 found=
 response=
 while read pattern
 do
-  # empty lines preceeding pattern
+  # empty lines preceding pattern
   if test -z "${pattern}"; then
     continue
   fi

--- a/setup/pkg.m4
+++ b/setup/pkg.m4
@@ -86,7 +86,7 @@ dnl Check to see whether a particular set of modules exists. Similar to
 dnl PKG_CHECK_MODULES(), but does not set variables or print errors.
 dnl
 dnl Please remember that m4 expands AC_REQUIRE([PKG_PROG_PKG_CONFIG])
-dnl only at the first occurence in configure.ac, so if the first place
+dnl only at the first occurrence in configure.ac, so if the first place
 dnl it's called might be skipped (such as if it is within an "if", you
 dnl have to call PKG_CHECK_EXISTS manually
 AC_DEFUN([PKG_CHECK_EXISTS],

--- a/standard.iso
+++ b/standard.iso
@@ -340,10 +340,10 @@ identifier i;
 @@
 i++; <=> ++i; <=> i+=1; <=> i=i+1;
 
-// I would like to avoid the following rule, but we cant transform a ++i
+// I would like to avoid the following rule, but we can't transform a ++i
 // in i++ everywhere. We can do it only when the instruction is alone,
 // such as when there is not stuff around it (not as in x = i++) That's why in
-// the previous iso, we have explicitely force the i++ do be alone with
+// the previous iso, we have explicitly force the i++ do be alone with
 // the ';'. But unfortunately in the last expression of the for there is
 // no ';' so the previous rule cannot be applied, hence this special
 // case.

--- a/tests/cst.cocci
+++ b/tests/cst.cocci
@@ -1,4 +1,4 @@
-// we cant say snd_magic_cast(E1, E2, E3) because E3 
+// we can't say snd_magic_cast(E1, E2, E3) because E3 
 // is not an expression. it is an action, which is not even exactly 
 // a statement.
 @@

--- a/tests/failing_andany.cocci
+++ b/tests/failing_andany.cocci
@@ -1,5 +1,5 @@
 /* This test case shows that the andany optimization doesn't work.  This
-optmization requires that the left argument of the conjunction have at most
+optimization requires that the left argument of the conjunction have at most
 one match.  This will always be true because every function has only one
 starting open brace.  But the pattern inside can be matched according to
 two environments, as illustrated in smc_probe1. That is, the rule should

--- a/tests/gcc_min_max.cocci
+++ b/tests/gcc_min_max.cocci
@@ -1,5 +1,5 @@
 // Deprecated min/max http://gcc.gnu.org/onlinedocs/gcc-4.0.1/gcc/Deprecated-Features.html
-// Only works if "algorithm" is allready included
+// Only works if "algorithm" is already included
 // This spatch is on hold until coccinelle is extended to support >?,<?,>?=,<?=
 @@
 expression x,y;

--- a/tests/int2bool-local.cocci
+++ b/tests/int2bool-local.cocci
@@ -38,7 +38,7 @@ f@p(...) {
 ...when any
 }
 
-/* match all acceptable complex assignement */
+/* match all acceptable complex assignment */
 @valid_assign exists@
 identifier eligible_var.f, boolean_function.fbool;
 local idexpression {int, u8, u1, u2, u4, u16, u32, char} eligible_var.x;

--- a/tests/labels_metastatement.res
+++ b/tests/labels_metastatement.res
@@ -8,7 +8,7 @@ int foo(int i) {
       foo();
   }
   foo();
-  } // we dont want that it add both foo on the } and on the endif
+  } // we don't want that it add both foo on the } and on the endif
     // (note: but need correct endif accrochage)
   foo();
 

--- a/tests/operators.cocci
+++ b/tests/operators.cocci
@@ -53,7 +53,7 @@ f@p(...) {
 ...when any
 }
 
-/* match all acceptable complex assignement */
+/* match all acceptable complex assignment */
 @valid_assign exists@
 identifier eligible_var.f, boolean_function.fbool;
 local idexpression {int, u8, u1, u2, u4, u16, u32, char} eligible_var.x;

--- a/tests/pdbgg.c
+++ b/tests/pdbgg.c
@@ -1,4 +1,4 @@
-/* regression if remove the definintion of PDBGG in standard.h: 
+/* regression if remove the definition of PDBGG in standard.h: 
 
 Great: a test file now works: /home/pad/linux/arch/mips/alchemy/common/au1xxx_irqmap.c
 PBBBBBBBB: a test file does not work anymore!!! : /home/pad/linux/arch/powerpc/boot/ps3.c

--- a/tests/proto_ver2.c
+++ b/tests/proto_ver2.c
@@ -378,7 +378,7 @@ dch_fill_fifo(struct IsdnCardState *cs)
 	cs->writeisacfifo(cs, ptr, count);
 	cs->writeisac(cs, IPACX_CMDRD, cmd);
   
-  // set timeout for transmission contol
+  // set timeout for transmission control
 	if (test_and_set_bit(FLG_DBUSY_TIMER, &cs->HW_Flags)) {
 		debugl1(cs, "dch_fill_fifo dbusytimer running");
 		del_timer(&cs->dbusytimer);

--- a/tests/proto_ver2.res
+++ b/tests/proto_ver2.res
@@ -377,7 +377,7 @@ dch_fill_fifo(struct IsdnCardState *cs)
 	cs->writeisacfifo(cs, ptr, count);
 	cs->writeisac(cs, IPACX_CMDRD, cmd);
   
-  // set timeout for transmission contol
+  // set timeout for transmission control
 	if (test_and_set_bit(FLG_DBUSY_TIMER, &cs->HW_Flags)) {
 		debugl1(cs, "dch_fill_fifo dbusytimer running");
 		del_timer(&cs->dbusytimer);

--- a/tests/test1_ver1.c
+++ b/tests/test1_ver1.c
@@ -1,7 +1,7 @@
 void main(int foo) {
 
   f(1);
-  f(1); // if uncoment then problems
+  f(1); // if uncomment then problems
   g(2);
   g(2);// if uncomment then problems
   if(1) {

--- a/tests/test1_ver2.c
+++ b/tests/test1_ver2.c
@@ -1,7 +1,7 @@
 void main(int foo) {
 
   f(1);
-  //f(1); // if uncoment then problems
+  //f(1); // if uncomment then problems
   g(2);
   //g(2);// if uncomment then problems
   if(1) {

--- a/tests/test9.c
+++ b/tests/test9.c
@@ -1,7 +1,7 @@
 void main(int foo) {
 
   f(1);
-//  f(1); // if uncoment then problems
+//  f(1); // if uncomment then problems
   g(2);
   if(1) {
     h(3);

--- a/tests/test9.res
+++ b/tests/test9.res
@@ -1,7 +1,7 @@
 void main(int foo) {
 
   f(1);
-//  f(1); // if uncoment then problems
+//  f(1); // if uncomment then problems
   g(2);
   if(1) {
     h(1, 3);

--- a/tests/test9_ver1.c
+++ b/tests/test9_ver1.c
@@ -1,7 +1,7 @@
 void main(int foo) {
 
   f(1);
-  f(1); // if uncoment then problems
+  f(1); // if uncomment then problems
   g(2);
   if(1) {
     h(3);

--- a/tools/cocci-send-email.perl
+++ b/tools/cocci-send-email.perl
@@ -886,7 +886,7 @@ sub sanitize_address {
 # domain name that corresponds the IP address in the HELO/EHLO
 # handshake. This is used to verify the connection and prevent
 # spammers from trying to hide their identity. If the DNS and IP don't
-# match, the receiveing MTA may deny the connection.
+# match, the receiving MTA may deny the connection.
 #
 # Here is a deny example of Net::SMTP with the default "localhost.localdomain"
 #

--- a/tools/extract_c_and_res.ml
+++ b/tools/extract_c_and_res.ml
@@ -9,7 +9,7 @@ open Common
 (*****************************************************************************)
 (*  *)
 (*****************************************************************************)
-(* requirments:
+(* requirements:
  *  - extract from one git commit, or from a set of git commits
  *  - files from drivers/ and also from other directories now
  *  - .c and .h, local .h and also not local .h

--- a/tools/lic.ml
+++ b/tools/lic.ml
@@ -45,7 +45,7 @@ let (+>) o f = f o
 let cat file =
   let chan = open_in file in
   let rec cat_aux acc ()  =
-      (* cant do input_line chan::aux() cos ocaml eval from right to left ! *)
+      (* can't do input_line chan::aux() cos ocaml eval from right to left ! *)
     let (b, l) = try (true, input_line chan) with End_of_file -> (false, "") in
     if b
     then cat_aux (l::acc) ()

--- a/tools/licensify-new.ml
+++ b/tools/licensify-new.ml
@@ -51,7 +51,7 @@ let (+>) o f = f o
 let cat file =
   let chan = open_in file in
   let rec cat_aux acc ()  =
-      (* cant do input_line chan::aux() cos ocaml eval from right to left ! *)
+      (* can't do input_line chan::aux() cos ocaml eval from right to left ! *)
     let (b, l) = try (true, input_line chan) with End_of_file -> (false, "") in
     if b
     then cat_aux (l::acc) ()

--- a/tools/licensify.ml
+++ b/tools/licensify.ml
@@ -78,7 +78,7 @@ let (+>) o f = f o
 let cat file =
   let chan = open_in file in
   let rec cat_aux acc ()  =
-      (* cant do input_line chan::aux() cos ocaml eval from right to left ! *)
+      (* can't do input_line chan::aux() cos ocaml eval from right to left ! *)
     let (b, l) = try (true, input_line chan) with End_of_file -> (false, "") in
     if b
     then cat_aux (l::acc) ()

--- a/tools/pycocci
+++ b/tools/pycocci
@@ -21,7 +21,7 @@ class ExecutionError(ReqError):
         self.error_code = errcode
 
 class Req:
-    "To be used for verifying binay package dependencies on Python code"
+    "To be used for verifying binary package dependencies on Python code"
     def __init__(self, chatty=True):
         self.all_reqs_ok = True
         self.debug = False

--- a/tools/spgen/source/meta_variable.ml
+++ b/tools/spgen/source/meta_variable.ml
@@ -517,7 +517,7 @@ let metavar_combiner rn =
     | _ -> fn v in
 
 (*
-  Not used for now, visiter not parameterized by this...
+  Not used for now, visitor not parameterized by this...
   let define_paramfn c fn v =
     match Ast0.unwrap v with
     | Ast0.MetaDParamList(mc, listlen, pure) ->


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell

Note: repertory "bundles" ignored.