### PR TITLE
Fix #170 - remove camlp4 remnants

### DIFF
--- a/commons/common.ml
+++ b/commons/common.ml
@@ -4409,18 +4409,6 @@ open B_Array
 open Bigarray
 *)
 
-
-(* for the string_of auto generation of camlp4
-val b_array_string_of_t : 'a -> 'b -> string
-val bigarray_string_of_int16_unsigned_elt : 'a -> string
-val bigarray_string_of_c_layout : 'a -> string
-let b_array_string_of_t f a = "<>"
-let bigarray_string_of_int16_unsigned_elt a = "<>"
-let bigarray_string_of_c_layout a = "<>"
-
-*)
-
-
 (*****************************************************************************)
 (* Set. Have a look too at set*.mli  *)
 (*****************************************************************************)

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,6 @@ Build-Depends:
  python-support (>= 0.6),
  menhir (>= 20090204.dfsg),
  libmenhir-ocaml-dev (>= 20090204.dfsg),
- libsexplib-camlp4-dev,
  libpcre-ocaml-dev,
  texlive-latex-base,
  texlive-latex-recommended,

--- a/setup/ocaml.m4
+++ b/setup/ocaml.m4
@@ -114,41 +114,6 @@ AC_DEFUN([AC_PROG_OCAMLYACC],
 ])
 
 
-AC_DEFUN([AC_PROG_CAMLP4],
-[dnl
-  AC_REQUIRE([AC_PROG_OCAML])dnl
-
-  # checking for camlp4
-  AC_PATH_TOOL([CAMLP4],[camlp4],[no])
-  if test "$CAMLP4" != "no"; then
-     TMPVERSION=`$CAMLP4 -v 2>&1| sed -n -e 's|.*version *\(.*\)$|\1|p'`
-     if test "$TMPVERSION" != "$OCAMLVERSION" ; then
-	AC_MSG_RESULT([versions differs from ocamlc])
-        CAMLP4=no
-     fi
-  fi
-  AC_SUBST([CAMLP4])
-
-  # checking for companion tools
-  AC_PATH_TOOL([CAMLP4BOOT],[camlp4boot],[no])
-  AC_PATH_TOOL([CAMLP4O],[camlp4o],[no])
-  AC_PATH_TOOL([CAMLP4OF],[camlp4of],[no])
-  AC_PATH_TOOL([CAMLP4OOF],[camlp4oof],[no])
-  AC_PATH_TOOL([CAMLP4ORF],[camlp4orf],[no])
-  AC_PATH_TOOL([CAMLP4PROF],[camlp4prof],[no])
-  AC_PATH_TOOL([CAMLP4R],[camlp4r],[no])
-  AC_PATH_TOOL([CAMLP4RF],[camlp4rf],[no])
-  AC_SUBST([CAMLP4BOOT])
-  AC_SUBST([CAMLP4O])
-  AC_SUBST([CAMLP4OF])
-  AC_SUBST([CAMLP4OOF])
-  AC_SUBST([CAMLP4ORF])
-  AC_SUBST([CAMLP4PROF])
-  AC_SUBST([CAMLP4R])
-  AC_SUBST([CAMLP4RF])
-])
-
-
 AC_DEFUN([AC_PROG_FINDLIB],
 [dnl
   dnl  AC_REQUIRE([AC_PROG_OCAML])dnl

--- a/setup/replies.txt
+++ b/setup/replies.txt
@@ -4,12 +4,6 @@ $(ocamllibdir)
 
 
 
-ocamlfind query camlp4
-
-$(ocamllibdir)/camlp4
-
-
-
 pkg-config --atleast-pkgconfig-version
 
 


### PR DESCRIPTION
Remove camlp4 mentions everywhere except `bundles/` directory,

See https://github.com/coccinelle/coccinelle/search?q=camlp4&unscoped_q=camlp4 and https://github.com/coccinelle/coccinelle/issues/170 for more information.