### PR TITLE
fix dependency for parsing_cocci/cocci_args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ STDCOMPAT_USERS := parsing_c/type_annoter_c cocci parsing_cocci/check_meta \
 	parsing_cocci/id_utils parsing_cocci/insert_plus \
 	parsing_cocci/lexer_cocci ocaml/yes_prepare_ocamlcocci \
 	tools/spgen/source/user_input tools/spgen/source/spgen_interactive \
-	parsing_c/flag_parsing_c commons/common
+	parsing_c/flag_parsing_c commons/common parsing_cocci/cocci_args
 
 SHOW_CLEAN := @echo "CLEAN    "
 SHOW_OCAMLC := @echo "OCAMLC   "


### PR DESCRIPTION
parsing_cocci/cocci_args depends on the Stdcompat library, but was not
part of the STDCOMPAT_USERS variable. This results in build failures if
Make is run using -j to build in parallel.

Fix this by ensuring that parsing_cocci/cocci_args is included in the
STDCOMPAT_USERS variable, ensuring that a proper dependency on
STDCOMPAT_LIB is created by Make.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>