### PR TITLE
Add missing dependency constraint in the opam file

### DIFF
--- a/coccinelle.opam
+++ b/coccinelle.opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind"
   "pcre"
   "stdcompat"
-  "pyml"
+  "pyml" {>= "20190626"}
   "conf-pkg-config"
   "conf-python-3"
   "conf-python-3-dev"


### PR DESCRIPTION
With older versions it will fail with:
```
#=== ERROR while compiling coccinelle.1.0.8 ===================================#
# context              2.1.0~alpha | linux/x86_64 | ocaml-variants.4.11.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.11.0+trunk/.opam-switch/build/coccinelle.1.0.8
# command              /usr/bin/make all.opt
# exit-code            2
# env-file             ~/.opam/log/coccinelle-6-6ef1df.env
# output-file          ~/.opam/log/coccinelle-6-6ef1df.out
### output ###
# [...]
# OCAMLOPT  ocaml/run_ocamlcocci.ml
# OCAMLOPT  -o ocaml/ocaml.cmxa
# OCAMLC    python/pycocci_aux.mli
# OCAMLOPT  python/pycocci_aux.ml
# OCAMLC    python/yes_pycocci.mli
# OCAMLOPT  python/yes_pycocci.ml
# File "python/yes_pycocci.ml", line 77, characters 15-46:
# 77 |       ~parents:[pycocci_get_class_type parent]
#                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type 'a list
#        but an expression was expected of type Py.Object.t = Pytypes.pyobject
# make: *** [Makefile:426: python/yes_pycocci.cmx] Error 2
```

*Already fixed in opam-repository in https://github.com/ocaml/opam-repository/pull/16466*