### PR TITLE
Compatibility with Menhir 20200525.

### DIFF
--- a/parsing_cocci/parser_cocci_menhir.mly
+++ b/parsing_cocci/parser_cocci_menhir.mly
@@ -14,8 +14,10 @@ functions to be declared as local variables *)
 (* Not clear how to let a function have a parameter of type void.  At the
 moment, void is allowed to be the type of a variable, which is wrong, and a
 parameter needs both a type and an identifier *)
-module Ast0 = Ast0_cocci
-module Ast = Ast_cocci
+
+(* Do not define aliases for the modules [Ast0_cocci] and [Ast_cocci].
+   With Menhir >= 20200525, this causes incorrect types to be inferred. *)
+
 module P = Parse_aux
 module U = Unparse_ast0
 
@@ -56,8 +58,8 @@ let rec adjacent_ellipsis = function
 
 let build_arg = function
   | Arg arg -> arg
-  | Ellipsis e -> Ast0.wrap (Ast0.Pdots(P.clt2mcode "..." e))
-  | Separator comma -> Ast0.wrap (Ast0.PComma (P.clt2mcode "," comma))
+  | Ellipsis e -> Ast0_cocci.wrap (Ast0_cocci.Pdots(P.clt2mcode "..." e))
+  | Separator comma -> Ast0_cocci.wrap (Ast0_cocci.PComma (P.clt2mcode "," comma))
   | VAEllipsis _ -> assert false
   | Nothing -> assert false
 
@@ -108,7 +110,7 @@ let coerce_tmeta newty name builder matcher =
 let tmeta_to_type (name,cstr,pure,clt) =
   (coerce_tmeta "a type" name (TMetaType(name,cstr,pure,clt))
      (function TMetaType(_,_,_,_) -> true | _ -> false));
-  Ast0.wrap(Ast0.MetaType(P.clt2mcode name clt,cstr,pure))
+  Ast0_cocci.wrap(Ast0_cocci.MetaType(P.clt2mcode name clt,cstr,pure))
 
 let tmeta_to_field (name,cstr,pure,clt) =
   (coerce_tmeta "a field" name (TMetaField(name,cstr,pure,clt))
@@ -119,27 +121,27 @@ let tmeta_to_exp (name,cstr,pure,clt) =
   (coerce_tmeta "an expression" name
      (TMetaExp(name,cstr,pure,None,clt,None))
      (function TMetaExp(_,_,_,_,_,_) -> true | _ -> false));
-  Ast0.wrap
-    (Ast0.MetaExpr(P.clt2mcode name clt,cstr,None,Ast.ANY,pure,None))
+  Ast0_cocci.wrap
+    (Ast0_cocci.MetaExpr(P.clt2mcode name clt,cstr,None,Ast_cocci.ANY,pure,None))
 
 let tmeta_to_param (name,cstr,pure,clt) =
   (coerce_tmeta "a parameter" name (TMetaParam(name,cstr,pure,clt))
      (function TMetaParam(_,_,_,_) -> true | _ -> false));
-  Ast0.wrap(Ast0.MetaParam(P.clt2mcode name clt,cstr,pure))
+  Ast0_cocci.wrap(Ast0_cocci.MetaParam(P.clt2mcode name clt,cstr,pure))
 
 let tmeta_to_assignOp (name,cstr,pure,clt) =
   (coerce_tmeta "an assignment operator" name
      (TMetaAssignOp(name,cstr,pure,clt))
      (function TMetaAssignOp(_,_,_,_) -> true | _ -> false));
-  Ast0.wrap
-    (Ast0.MetaAssign(P.clt2mcode name clt,cstr, pure))
+  Ast0_cocci.wrap
+    (Ast0_cocci.MetaAssign(P.clt2mcode name clt,cstr, pure))
 
 let tmeta_to_binaryOp (name,cstr,pure,clt) =
   (coerce_tmeta "a binary operator" name
      (TMetaBinaryOp(name,cstr,pure,clt))
      (function TMetaBinaryOp(_,_,_,_) -> true | _ -> false));
-  Ast0.wrap
-    (Ast0.MetaBinary(P.clt2mcode name clt,cstr, pure),clt)
+  Ast0_cocci.wrap
+    (Ast0_cocci.MetaBinary(P.clt2mcode name clt,cstr, pure),clt)
 
 let tmeta_to_statement (name,cstr,pure,clt) =
   (coerce_tmeta "a statement" name (TMetaType(name,cstr,pure,clt))
@@ -148,49 +150,49 @@ let tmeta_to_statement (name,cstr,pure,clt) =
 
 let tmeta_to_seed_id (name,pure,clt) =
   (coerce_tmeta "an identifier" name
-     (TMetaId(name,Ast.CstrTrue,Ast.NoVal,pure,clt))
+     (TMetaId(name,Ast_cocci.CstrTrue,Ast_cocci.NoVal,pure,clt))
      (function TMetaId(_,_,_,_,_) -> true | _ -> false));
-  Ast.SeedId name
+  Ast_cocci.SeedId name
 
 let tmeta_to_ident (name,cstr,pure,clt) =
   (coerce_tmeta "an identifier" name
-     (TMetaId(name,cstr,Ast.NoVal,pure,clt))
+     (TMetaId(name,cstr,Ast_cocci.NoVal,pure,clt))
      (function TMetaId(_,_,_,_,_) -> true | _ -> false));
-  Ast0.wrap(Ast0.MetaId(P.clt2mcode name clt,cstr,Ast.NoVal,pure))
+  Ast0_cocci.wrap(Ast0_cocci.MetaId(P.clt2mcode name clt,cstr,Ast_cocci.NoVal,pure))
 
 and  arithOp = function
-    Ast.Plus -> "+"
-  | Ast.Minus -> "-"
-  | Ast.Mul -> "*"
-  | Ast.Div -> "/"
-  | Ast.Min -> "<?"
-  | Ast.Max -> ">?"
-  | Ast.Mod -> "%"
-  | Ast.DecLeft -> "<<"
-  | Ast.DecRight -> ">>"
-  | Ast.And -> "&"
-  | Ast.Or -> "|"
-  | Ast.Xor -> "^"
+    Ast_cocci.Plus -> "+"
+  | Ast_cocci.Minus -> "-"
+  | Ast_cocci.Mul -> "*"
+  | Ast_cocci.Div -> "/"
+  | Ast_cocci.Min -> "<?"
+  | Ast_cocci.Max -> ">?"
+  | Ast_cocci.Mod -> "%"
+  | Ast_cocci.DecLeft -> "<<"
+  | Ast_cocci.DecRight -> ">>"
+  | Ast_cocci.And -> "&"
+  | Ast_cocci.Or -> "|"
+  | Ast_cocci.Xor -> "^"
 
 and  logicalOp = function
-    Ast.Inf -> "<"
-  | Ast.Sup -> ">"
-  | Ast.InfEq -> "<="
-  | Ast.SupEq -> ">="
-  | Ast.Eq -> "=="
-  | Ast.NotEq -> "!="
-  | Ast.AndLog -> "&&"
-  | Ast.OrLog -> "||"
+    Ast_cocci.Inf -> "<"
+  | Ast_cocci.Sup -> ">"
+  | Ast_cocci.InfEq -> "<="
+  | Ast_cocci.SupEq -> ">="
+  | Ast_cocci.Eq -> "=="
+  | Ast_cocci.NotEq -> "!="
+  | Ast_cocci.AndLog -> "&&"
+  | Ast_cocci.OrLog -> "||"
 
 let mkarithop (op, clt) =
   let op' = P.clt2mcode op clt in
-  Ast0.wrap (Ast0.Arith op')
+  Ast0_cocci.wrap (Ast0_cocci.Arith op')
 
 let mklogop (op,clt) =
   let op' = P.clt2mcode op clt in
-  Ast0.wrap (Ast0.Logical op')
+  Ast0_cocci.wrap (Ast0_cocci.Logical op')
 
-let unknown_type = Ast0.wrap (Ast0.BaseType (Ast.Unknown, []))
+let unknown_type = Ast0_cocci.wrap (Ast0_cocci.BaseType (Ast_cocci.Unknown, []))
 
 let check_constraint_allowed () =
   if !Data.in_iso then
@@ -201,14 +203,14 @@ let check_constraint_allowed () =
 let inline_id aft = function
     TMetaId((nm,constraints,seed,pure,clt)) ->
       let clt = P.set_aft aft clt in
-      Ast0.wrap
-	(Ast0.MetaId(P.clt2mcode nm clt,constraints,seed,pure))
+      Ast0_cocci.wrap
+	(Ast0_cocci.MetaId(P.clt2mcode nm clt,constraints,seed,pure))
   | TIdent((nm,clt)) ->
       let clt = P.set_aft aft clt in
-      Ast0.wrap(Ast0.Id(P.clt2mcode nm clt))
+      Ast0_cocci.wrap(Ast0_cocci.Id(P.clt2mcode nm clt))
   | TSymId(nm,clt) ->
       let clt = P.set_aft aft clt in
-      Ast0.wrap(Ast0.Id(P.clt2mcode nm clt))
+      Ast0_cocci.wrap(Ast0_cocci.Id(P.clt2mcode nm clt))
   | _ ->
       raise (Semantic_cocci.Semantic "unexpected name for a #define")
 %}
@@ -385,7 +387,7 @@ rule_name
 %start never_used
 %type <unit> never_used
 
-%type <'a * Ast0.constraints> pure_ident_or_meta_ident_with_constraints
+%type <'a * Ast0_cocci.constraints> pure_ident_or_meta_ident_with_constraints
 
 %%
 
@@ -405,7 +407,7 @@ plus_ty_main: plus_ty_body EOF { $1 } | p=plus_ty_body TArobArob { p }
 | p=plus_ty_body TArob { p }
 plus_id_main: plus_id_body EOF { $1 } | p=plus_id_body TArobArob { p }
 | p=plus_id_body TArob { p }
-meta_main: m=metadec   { m (!Ast0.rule_name) }
+meta_main: m=metadec   { m (!Ast0_cocci.rule_name) }
 iso_meta_main: m=metadec { m "" }
 
 /*****************************************************************************
@@ -414,11 +416,11 @@ iso_meta_main: m=metadec { m "" }
 *****************************************************************************/
 
 pure:
-  TPure          { Ast0.Pure }
-| TContext       { Ast0.Context }
-| TPure TContext { Ast0.PureContext }
-| TContext TPure { Ast0.PureContext }
-| /* empty */    { Ast0.Impure }
+  TPure          { Ast0_cocci.Pure }
+| TContext       { Ast0_cocci.Context }
+| TPure TContext { Ast0_cocci.PureContext }
+| TContext TPure { Ast0_cocci.PureContext }
+| /* empty */    { Ast0_cocci.Impure }
 
 iso_rule_name:
   nm=pure_ident TArob { P.make_iso_rule_name_result (P.id2name nm) }
@@ -445,26 +447,26 @@ extends:
     { !Data.install_bindings (parent) }
 
 depends:
-  /* empty */              { Ast0.NoDep }
-| TDepends TOn parents=dep { Ast0.ExistsDep parents }
-| TDepends TOn TExists parents=dep { Ast0.ExistsDep parents }
-| TDepends TOn TForall parents=dep { Ast0.ForallDep parents }
+  /* empty */              { Ast0_cocci.NoDep }
+| TDepends TOn parents=dep { Ast0_cocci.ExistsDep parents }
+| TDepends TOn TExists parents=dep { Ast0_cocci.ExistsDep parents }
+| TDepends TOn TForall parents=dep { Ast0_cocci.ForallDep parents }
 
 dep:
-  TRuleName        { Ast0.Dep $1 }
-| TBang TRuleName  { Ast0.AntiDep (Ast0.Dep $2) }
+  TRuleName        { Ast0_cocci.Dep $1 }
+| TBang TRuleName  { Ast0_cocci.AntiDep (Ast0_cocci.Dep $2) }
 | TBang TOPar dep TCPar
-                   { Ast0.AntiDep $3 }
-| TEver TRuleName  { Ast0.EverDep $2 }
-| TNever TRuleName { Ast0.NeverDep $2 }
-| dep TAndLog dep  { Ast0.AndDep($1, $3) }
-| dep TOrLog  dep  { Ast0.OrDep ($1, $3) }
+                   { Ast0_cocci.AntiDep $3 }
+| TEver TRuleName  { Ast0_cocci.EverDep $2 }
+| TNever TRuleName { Ast0_cocci.NeverDep $2 }
+| dep TAndLog dep  { Ast0_cocci.AndDep($1, $3) }
+| dep TOrLog  dep  { Ast0_cocci.OrDep ($1, $3) }
 | TOPar dep TCPar  { $2 }
 | TFile TIn TString
     { let nm = P.id3name $3 in
       if !Flag.dir = ""
-      then Ast0.FileIn nm
-      else Ast0.FileIn(Filename.concat !Flag.dir nm) }
+      then Ast0_cocci.FileIn nm
+      else Ast0_cocci.FileIn(Filename.concat !Flag.dir nm) }
 
 choose_iso:
   TUsing separated_nonempty_list(TComma,TString) { List.map P.id3name $2 }
@@ -473,15 +475,15 @@ disable:
   TDisable separated_nonempty_list(TComma,pure_ident) { List.map P.id2name $2 }
 
 exists:
-  TExists { Ast.Exists }
-| TForall { Ast.Forall }
-|         { Ast.Undetermined }
+  TExists { Ast_cocci.Exists }
+| TForall { Ast_cocci.Forall }
+|         { Ast_cocci.Undetermined }
 
 is_expression: // for more flexible parsing of top level expressions
-              { Ast.AnyP }
-| TExpression { Ast.ExpP }
-| TIdentifier { Ast.IdP }
-| TType       { Ast.TyP }
+              { Ast_cocci.AnyP }
+| TExpression { Ast_cocci.ExpP }
+| TIdentifier { Ast_cocci.IdP }
+| TType       { Ast_cocci.TyP }
 
 include_main:
   list(incl) TArob     { $1 }
@@ -540,8 +542,8 @@ metadec:
     { (if !Data.in_generating
       then failwith "position variables not allowed in a generated rule file");
       let kindfn arity name pure check_meta constraints =
-	let tok = check_meta(Ast.MetaPosDecl(arity,name)) in
-	let any = match a with None -> Ast.PER | Some _ -> Ast.ALL in
+	let tok = check_meta(Ast_cocci.MetaPosDecl(arity,name)) in
+	let any = match a with None -> Ast_cocci.PER | Some _ -> Ast_cocci.ALL in
 	!Data.add_pos_meta name constraints any; tok in
     P.create_metadec_with_constraints ar false kindfn ids }
 | ar=arity TComments
@@ -552,7 +554,7 @@ metadec:
     { (if !Data.in_generating
       then failwith "comment variables not allowed in a generated rule file");
       let kindfn arity name pure check_meta constraints =
-	let tok = check_meta(Ast.MetaComDecl(arity,name)) in
+	let tok = check_meta(Ast_cocci.MetaComDecl(arity,name)) in
 	!Data.add_com_meta name constraints; tok in
     P.create_metadec_with_constraints ar false kindfn ids }
 | ar=arity ispure=pure
@@ -560,7 +562,7 @@ metadec:
     ids=comma_list(pure_ident_or_meta_ident_with_constraints) TMPtVirg
     { P.create_len_metadec ar ispure
 	(fun lenname arity name pure check_meta cstr ->
-	  let tok = check_meta(Ast.MetaParamListDecl(arity,name,lenname)) in
+	  let tok = check_meta(Ast_cocci.MetaParamListDecl(arity,name,lenname)) in
 	  !Data.add_paramlist_meta name lenname cstr pure; tok)
 	len ids }
 | ar=arity ispure=pure
@@ -568,7 +570,7 @@ metadec:
     ids=comma_list(pure_ident_or_meta_ident_with_constraints) TMPtVirg
     { P.create_len_metadec ar ispure
 	(fun lenname arity name pure check_meta cstr ->
-	  let tok = check_meta(Ast.MetaExpListDecl(arity,name,lenname)) in
+	  let tok = check_meta(Ast_cocci.MetaExpListDecl(arity,name,lenname)) in
 	  !Data.add_explist_meta name lenname cstr pure; tok)
 	len ids }
 | ar=arity ispure=pure
@@ -576,7 +578,7 @@ metadec:
     ids=comma_list(pure_ident_or_meta_ident_with_constraints) TMPtVirg
     { P.create_len_metadec ar ispure
 	(fun lenname arity name pure check_meta cstr ->
-	  let tok = check_meta(Ast.MetaFieldListDecl(arity,name,lenname)) in
+	  let tok = check_meta(Ast_cocci.MetaFieldListDecl(arity,name,lenname)) in
 	  !Data.add_field_list_meta name lenname cstr pure; tok)
 	len ids }
 | ar=arity ispure=pure
@@ -584,7 +586,7 @@ metadec:
     ids=comma_list(pure_ident_or_meta_ident_with_constraints) TMPtVirg
     { P.create_len_metadec ar ispure
 	(fun lenname arity name pure check_meta cstr ->
-	  let tok = check_meta(Ast.MetaInitListDecl(arity,name,lenname)) in
+	  let tok = check_meta(Ast_cocci.MetaInitListDecl(arity,name,lenname)) in
 	  !Data.add_initlist_meta name lenname cstr pure; tok)
 	len ids }
 | ar=arity ispure=pure
@@ -592,14 +594,14 @@ metadec:
     ids=comma_list(pure_ident_or_meta_ident_with_constraints) TMPtVirg
     { P.create_len_metadec ar ispure
 	(fun lenname arity name pure check_meta cstr ->
-	  let tok = check_meta(Ast.MetaDParamListDecl(arity,name,lenname)) in
+	  let tok = check_meta(Ast_cocci.MetaDParamListDecl(arity,name,lenname)) in
 	  !Data.add_dparamlist_meta name lenname cstr pure; tok)
 	len ids }
 | ar=arity ispure=pure TStatement Tlist TOCro len=list_len TCCro
     ids=comma_list(pure_ident_or_meta_ident_with_constraints) TMPtVirg
     { P.create_len_metadec ar ispure
 	(fun lenname arity name pure check_meta cstr ->
-	  let tok = check_meta(Ast.MetaStmListDecl(arity,name,lenname)) in
+	  let tok = check_meta(Ast_cocci.MetaStmListDecl(arity,name,lenname)) in
 	  !Data.add_stmlist_meta name lenname cstr pure; tok)
 	len ids }
 | TSymbol ids=comma_list(pure_ident_or_symbol) TMPtVirg
@@ -610,40 +612,40 @@ metadec:
 | ar=arity TFormat
     ids=comma_list(pure_ident_or_meta_ident_with_constraints)
     TMPtVirg
-    { P.create_metadec_with_constraints ar Ast0.Impure
+    { P.create_metadec_with_constraints ar Ast0_cocci.Impure
 	(fun arity name pure check_meta constraints ->
-	  let tok = check_meta(Ast.MetaFmtDecl(arity,name)) in
+	  let tok = check_meta(Ast_cocci.MetaFmtDecl(arity,name)) in
 	  !Data.add_fmt_meta name constraints; tok)
     ids }
 | ar=arity TFormat Tlist
     ids=comma_list(pure_ident_or_meta_ident_with_constraints) TMPtVirg
-    { P.create_metadec_with_constraints ar Ast0.Impure
+    { P.create_metadec_with_constraints ar Ast0_cocci.Impure
 	(fun arity name pure check_meta cstr ->
-	  let len = Ast.AnyLen in
-	  let tok = check_meta(Ast.MetaFragListDecl(arity,name,len)) in
+	  let len = Ast_cocci.AnyLen in
+	  let tok = check_meta(Ast_cocci.MetaFragListDecl(arity,name,len)) in
 	  !Data.add_fmtlist_meta name cstr len; tok)
 	ids }
 | ar=arity
     TFormat Tlist TOCro len=list_len TCCro
     ids=comma_list(pure_ident_or_meta_ident_with_constraints) TMPtVirg
-    { P.create_len_metadec ar Ast0.Impure
+    { P.create_len_metadec ar Ast0_cocci.Impure
 	(fun lenname arity name pure check_meta cstr ->
-	  let tok = check_meta(Ast.MetaFragListDecl(arity,name,lenname)) in
+	  let tok = check_meta(Ast_cocci.MetaFragListDecl(arity,name,lenname)) in
 	  !Data.add_fmtlist_meta name cstr lenname; tok)
 	len ids }
 | ar=arity TBinary TOperator
     ids=comma_list(pure_ident_or_meta_ident_with_constraints) TMPtVirg
-    { P.create_metadec_with_constraints ar Ast0.Impure
+    { P.create_metadec_with_constraints ar Ast0_cocci.Impure
 	(fun arity name pure check_meta constraints ->
-	  let tok = check_meta(Ast.MetaBinaryOperatorDecl(arity,name)) in
+	  let tok = check_meta(Ast_cocci.MetaBinaryOperatorDecl(arity,name)) in
 	  !Data.add_binaryOp_meta name constraints pure; tok)
         ids }
 | ar=arity TAssignment TOperator
     ids=comma_list(pure_ident_or_meta_ident_with_constraints)
     TMPtVirg
-    { P.create_metadec_with_constraints ar Ast0.Impure
+    { P.create_metadec_with_constraints ar Ast0_cocci.Impure
 	(fun arity name pure check_meta constraints ->
-	  let tok = check_meta(Ast.MetaAssignmentOperatorDecl(arity,name)) in
+	  let tok = check_meta(Ast_cocci.MetaAssignmentOperatorDecl(arity,name)) in
 	  !Data.add_assignOp_meta name constraints pure; tok)
         ids }
 
@@ -667,12 +669,12 @@ list_len_pure:
 		    (List.assoc (snd nm) !Flag.defined_virtual_env))
     with Not_found | Failure _ ->
       begin
-	Common.Left ((Some "virtual",P.id2name $3),Ast.CstrTrue)
+	Common.Left ((Some "virtual",P.id2name $3),Ast_cocci.CstrTrue)
       end
     }
 
 delimited_list_len:
-  id=pure_ident_or_meta_ident { Common.Left (id, Ast.CstrTrue) }
+  id=pure_ident_or_meta_ident { Common.Left (id, Ast_cocci.CstrTrue) }
 | TOPar idcstr=pure_ident_or_meta_ident_with_constraints TCPar
     { Common.Left idcstr }
 | l=list_len_pure { l }
@@ -680,93 +682,93 @@ delimited_list_len:
 %inline metakind_fresh:
   TFresh TIdentifier
     { (fun name check_meta seed ->
-      let tok = check_meta(Ast.MetaFreshIdDecl(name,seed)) in
+      let tok = check_meta(Ast_cocci.MetaFreshIdDecl(name,seed)) in
       !Data.add_fresh_id_meta name seed; tok) }
 
 /* metavariable kinds with no constraints, etc */
 %inline metakind:
   TMetavariable
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaMetaDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaMetaDecl(arity,name)) in
       !Data.add_meta_meta name constraints pure; tok) }
 | TParameter
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaParamDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaParamDecl(arity,name)) in
       !Data.add_param_meta name constraints pure; tok) }
 | TParameter Tlist
     { (fun arity name pure check_meta constraints ->
-      let len = Ast.AnyLen in
-      let tok = check_meta(Ast.MetaParamListDecl(arity,name,len)) in
+      let len = Ast_cocci.AnyLen in
+      let tok = check_meta(Ast_cocci.MetaParamListDecl(arity,name,len)) in
       !Data.add_paramlist_meta name len constraints pure; tok) }
 | TExpression Tlist
     { (fun arity name pure check_meta constraints ->
-      let len = Ast.AnyLen in
-      let tok = check_meta(Ast.MetaExpListDecl(arity,name,len)) in
+      let len = Ast_cocci.AnyLen in
+      let tok = check_meta(Ast_cocci.MetaExpListDecl(arity,name,len)) in
       !Data.add_explist_meta name len constraints pure; tok) }
 /* | TType
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaTypeDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaTypeDecl(arity,name)) in
       !Data.add_type_meta name constraints pure; tok) } */
 | TInitialiser
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaInitDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaInitDecl(arity,name)) in
       !Data.add_init_meta name constraints pure; tok) }
 | TInitialiser Tlist
     { (fun arity name pure check_meta constraints ->
-      let len = Ast.AnyLen in
-      let tok = check_meta(Ast.MetaInitListDecl(arity,name,len)) in
+      let len = Ast_cocci.AnyLen in
+      let tok = check_meta(Ast_cocci.MetaInitListDecl(arity,name,len)) in
       !Data.add_initlist_meta name len constraints pure; tok) }
 | TStatement
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaStmDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaStmDecl(arity,name)) in
       !Data.add_stm_meta name constraints pure; tok) }
 | TDeclaration
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaDeclDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaDeclDecl(arity,name)) in
       !Data.add_decl_meta name constraints pure; tok) }
 | TField
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaFieldDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaFieldDecl(arity,name)) in
       !Data.add_field_meta name constraints pure; tok) }
 | TField Tlist
     { (fun arity name pure check_meta constraints ->
-      let len = Ast.AnyLen in
-      let tok = check_meta(Ast.MetaFieldListDecl(arity,name,len)) in
+      let len = Ast_cocci.AnyLen in
+      let tok = check_meta(Ast_cocci.MetaFieldListDecl(arity,name,len)) in
       !Data.add_field_list_meta name len constraints pure; tok) }
 | TStatement Tlist
     { (fun arity name pure check_meta constraints ->
-      let len = Ast.AnyLen in
-      let tok = check_meta(Ast.MetaStmListDecl(arity,name,len)) in
+      let len = Ast_cocci.AnyLen in
+      let tok = check_meta(Ast_cocci.MetaStmListDecl(arity,name,len)) in
       !Data.add_stmlist_meta name len constraints pure; tok) }
 | TIdentifier Tlist
     { (fun arity name pure check_meta constraints ->
-      let len = Ast.AnyLen in
-      let tok = check_meta(Ast.MetaDParamListDecl(arity,name,len)) in
+      let len = Ast_cocci.AnyLen in
+      let tok = check_meta(Ast_cocci.MetaDParamListDecl(arity,name,len)) in
       !Data.add_dparamlist_meta name len constraints pure; tok) }
 | TFunction
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaFuncDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaFuncDecl(arity,name)) in
       !Data.add_func_meta name constraints pure; tok) }
 | TLocal TFunction
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaLocalFuncDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaLocalFuncDecl(arity,name)) in
       !Data.add_local_func_meta name constraints pure;
       tok) }
 | TDeclarer
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaDeclarerDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaDeclarerDecl(arity,name)) in
       !Data.add_declarer_meta name constraints pure; tok) }
 | TIterator
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaIteratorDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaIteratorDecl(arity,name)) in
       !Data.add_iterator_meta name constraints pure; tok) }
 | TType
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaTypeDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaTypeDecl(arity,name)) in
       !Data.add_type_meta name constraints pure; tok) }
 | TError
     { (fun arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaErrDecl(arity,name)) in
+      let tok = check_meta(Ast_cocci.MetaErrDecl(arity,name)) in
       !Data.add_err_meta name constraints pure; tok) }
 | l=option(TLocal) TIdExpression ty=ioption(meta_exp_type)
     { (fun arity name pure check_meta constraints ->
@@ -774,11 +776,11 @@ delimited_list_len:
         None ->
           !Data.add_idexp_meta ty name constraints pure;
           let ty' = Common.map_option (List.map (Ast0toast.typeC false)) ty in
-          check_meta(Ast.MetaIdExpDecl(arity,name,ty'))
+          check_meta(Ast_cocci.MetaIdExpDecl(arity,name,ty'))
       | Some _ ->
           !Data.add_local_idexp_meta ty name constraints pure;
           let ty' = Common.map_option (List.map (Ast0toast.typeC false)) ty in
-          check_meta(Ast.MetaLocalIdExpDecl(arity,name,ty'))) }
+          check_meta(Ast_cocci.MetaLocalIdExpDecl(arity,name,ty'))) }
 | l=option(TLocal) TIdExpression m=nonempty_list(TMul)
     { (fun arity name pure check_meta constraints ->
       let ty = Some [P.ty_pointerify unknown_type m] in
@@ -786,62 +788,62 @@ delimited_list_len:
         None ->
           !Data.add_idexp_meta ty name constraints pure;
           let ty' = Common.map_option (List.map (Ast0toast.typeC false)) ty in
-          check_meta(Ast.MetaIdExpDecl(arity,name,ty'))
+          check_meta(Ast_cocci.MetaIdExpDecl(arity,name,ty'))
       | Some _ ->
           !Data.add_local_idexp_meta ty name constraints pure;
           let ty' = Common.map_option (List.map (Ast0toast.typeC false)) ty in
-          check_meta(Ast.MetaLocalIdExpDecl(arity,name,ty'))) }
+          check_meta(Ast_cocci.MetaLocalIdExpDecl(arity,name,ty'))) }
 | TGlobal TIdExpression ty=ioption(meta_exp_type)
     { (fun arity name pure check_meta constraints ->
       !Data.add_global_idexp_meta ty name constraints pure;
       let ty' = Common.map_option (List.map (Ast0toast.typeC false)) ty in
-      check_meta(Ast.MetaGlobalIdExpDecl(arity,name,ty'))) }
+      check_meta(Ast_cocci.MetaGlobalIdExpDecl(arity,name,ty'))) }
 | TGlobal TIdExpression m=nonempty_list(TMul)
     { (fun arity name pure check_meta constraints ->
       let ty = P.ty_pointerify unknown_type m in
       !Data.add_global_idexp_meta (Some [ty]) name constraints pure;
       let ty' = Some [Ast0toast.typeC false ty] in
-      check_meta(Ast.MetaGlobalIdExpDecl(arity,name,ty'))) }
+      check_meta(Ast_cocci.MetaGlobalIdExpDecl(arity,name,ty'))) }
 | TConstant ty=ioption(meta_exp_type)
     { (fun arity name pure check_meta constraints ->
       !Data.add_const_meta ty name constraints pure;
       let ty' = Common.map_option (List.map (Ast0toast.typeC false)) ty in
-      check_meta (Ast.MetaConstDecl(arity,name,ty'))) }
+      check_meta (Ast_cocci.MetaConstDecl(arity,name,ty'))) }
 
 %inline metakind_bitfield:
 | TExpression ty=expression_type
     { (fun lenname arity name pure check_meta constraints ->
       !Data.add_exp_meta (Some [ty]) name constraints pure lenname;
       let ty' = Some [Ast0toast.typeC false ty] in
-      check_meta (Ast.MetaExpDecl (arity, name, ty', lenname))) }
+      check_meta (Ast_cocci.MetaExpDecl (arity, name, ty', lenname))) }
 | TExpression
     { (fun lenname arity name pure check_meta constraints ->
-      let tok = check_meta(Ast.MetaExpDecl(arity,name,None,lenname)) in
+      let tok = check_meta(Ast_cocci.MetaExpDecl(arity,name,None,lenname)) in
       !Data.add_exp_meta None name constraints pure lenname; tok) }
 | vl=meta_exp_type // no error if use $1 but doesn't type check
     { (fun lenname arity name pure check_meta constraints ->
       let ty = Some vl in
       let cstr_expr = Some begin function c ->
-	match Ast0.unwrap c with
-	  Ast0.Constant(_) ->
+	match Ast0_cocci.unwrap c with
+	  Ast0_cocci.Constant(_) ->
 	    if not
 		(List.exists
 		   (fun ty ->
-		     match Ast0.unwrap ty with
-		       Ast0.BaseType (Ast.IntType, _) -> true
-		     | Ast0.BaseType (Ast.ShortType, _) -> true
-		     | Ast0.BaseType (Ast.LongType, _) -> true
+		     match Ast0_cocci.unwrap ty with
+		       Ast0_cocci.BaseType (Ast_cocci.IntType, _) -> true
+		     | Ast0_cocci.BaseType (Ast_cocci.ShortType, _) -> true
+		     | Ast0_cocci.BaseType (Ast_cocci.LongType, _) -> true
 			   | _ -> false)
 			 vl)
 		  then
 		    failwith "metavariable with int constraint must be an int"
 	      | _ -> ()
 	end in
-      Ast.cstr_iter { Ast.empty_cstr_transformer with Ast.cstr_expr }
+      Ast_cocci.cstr_iter { Ast_cocci.empty_cstr_transformer with Ast_cocci.cstr_expr }
 	constraints;
       !Data.add_exp_meta ty name constraints pure lenname;
       let ty' = Some (List.map (Ast0toast.typeC false) vl) in
-      let tok = check_meta (Ast.MetaExpDecl (arity,name,ty',lenname)) in
+      let tok = check_meta (Ast_cocci.MetaExpDecl (arity,name,ty',lenname)) in
       tok)
     }
 
@@ -849,12 +851,12 @@ delimited_list_len:
 %inline metakindnosym:
   TTypedef ids=comma_list(pure_ident_or_meta_ident_nosym2(TTypeId))
     { (ids,fun arity (_,name) pure check_meta ->
-      if arity = Ast.NONE && pure = Ast0.Impure
+      if arity = Ast_cocci.NONE && pure = Ast0_cocci.Impure
       then (!Data.add_type_name name; [])
       else raise (Semantic_cocci.Semantic "bad typedef")) }
 | TAttribute TName ids=comma_list(pure_ident_or_meta_ident_nosym2(Tattr))
     { (ids,fun arity (_,name) pure check_meta ->
-      if arity = Ast.NONE && pure = Ast0.Impure
+      if arity = Ast_cocci.NONE && pure = Ast0_cocci.Impure
       then
 	(!Data.add_attribute name;
 	 Flag.add_cocci_attribute_names name;
@@ -862,12 +864,12 @@ delimited_list_len:
       else raise (Semantic_cocci.Semantic "bad attribute")) }
 | TDeclarer TName ids=comma_list(pure_ident_or_meta_ident_nosym2(TDeclarerId))
     { (ids,fun arity (_,name) pure check_meta ->
-      if arity = Ast.NONE && pure = Ast0.Impure
+      if arity = Ast_cocci.NONE && pure = Ast0_cocci.Impure
       then (!Data.add_declarer_name name; [])
       else raise (Semantic_cocci.Semantic "bad declarer")) }
 | TIterator TName ids=comma_list(pure_ident_or_meta_ident_nosym2(TIteratorId))
     { (ids,fun arity (_,name) pure check_meta ->
-      if arity = Ast.NONE && pure = Ast0.Impure
+      if arity = Ast_cocci.NONE && pure = Ast0_cocci.Impure
       then (!Data.add_iterator_name name; [])
       else raise (Semantic_cocci.Semantic "bad iterator")) }
 
@@ -875,7 +877,7 @@ delimited_list_len:
   TIdentifier
     {
      let idfn arity name pure check_meta constraints =
-       let tok = check_meta(Ast.MetaIdDecl(arity,name)) in
+       let tok = check_meta(Ast_cocci.MetaIdDecl(arity,name)) in
        !Data.add_id_meta name constraints pure; tok in
      let virtfn arity name pure check_meta virtual_env =
        try
@@ -886,69 +888,69 @@ delimited_list_len:
 	   Common.union_set [name]
 	     !Iteration.parsed_virtual_identifiers;
 	 let name = ("virtual",name) in
-	 let tok = check_meta(Ast.MetaIdDecl(arity,name)) in
+	 let tok = check_meta(Ast_cocci.MetaIdDecl(arity,name)) in
 	 !Data.add_virt_id_meta_not_found name pure; tok in
      (idfn,virtfn) }
 
 expression_type:
   m=nonempty_list(TMul) { P.ty_pointerify unknown_type m }
 | Tenum m=list(TMul)
-    { P.ty_pointerify (Ast0.wrap (Ast0.EnumName (Ast0.make_mcode "", None))) m }
+    { P.ty_pointerify (Ast0_cocci.wrap (Ast0_cocci.EnumName (Ast0_cocci.make_mcode "", None))) m }
 | Tstruct m=list(TMul)
     { P.ty_pointerify
-        (Ast0.wrap
-           (Ast0.StructUnionName (Ast0.make_mcode Ast.Struct, None))) m }
+        (Ast0_cocci.wrap
+           (Ast0_cocci.StructUnionName (Ast0_cocci.make_mcode Ast_cocci.Struct, None))) m }
 | Tunion m=list(TMul)
     { P.ty_pointerify
-        (Ast0.wrap
-           (Ast0.StructUnionName (Ast0.make_mcode Ast.Union, None))) m }
+        (Ast0_cocci.wrap
+           (Ast0_cocci.StructUnionName (Ast0_cocci.make_mcode Ast_cocci.Union, None))) m }
 
 meta_exp_type:
   t=typedef_ctype
     { [t] }
 | t=typedef_ctype TOCro TCCro
-    { [Ast0.wrap
-         (Ast0.Array
+    { [Ast0_cocci.wrap
+         (Ast0_cocci.Array
             (t,
-             Ast0.make_mcode "", None, Ast0.make_mcode ""))] }
+             Ast0_cocci.make_mcode "", None, Ast0_cocci.make_mcode ""))] }
 | TOBrace t=comma_list(ctype) TCBrace m=list(TMul)
     { List.map (fun x -> P.ty_pointerify x m) t }
 
-arity: TWhy0  { Ast.OPT }
-     | TPlus0 { Ast.MULTI }
-     | /* empty */ { Ast.NONE }
+arity: TWhy0  { Ast_cocci.OPT }
+     | TPlus0 { Ast_cocci.MULTI }
+     | /* empty */ { Ast_cocci.NONE }
 
 /* ---------------------------------------------------------------------- */
 
 signable_types_no_ident:
   ty=Tchar
-    { Ast0.wrap(Ast0.BaseType(Ast.CharType,[P.clt2mcode "char" ty])) }
+    { Ast0_cocci.wrap(Ast0_cocci.BaseType(Ast_cocci.CharType,[P.clt2mcode "char" ty])) }
 | ty=Tshort
-    { Ast0.wrap(Ast0.BaseType(Ast.ShortType,[P.clt2mcode "short" ty])) }
+    { Ast0_cocci.wrap(Ast0_cocci.BaseType(Ast_cocci.ShortType,[P.clt2mcode "short" ty])) }
 | ty1=Tshort ty2=Tint
-    { Ast0.wrap
-	(Ast0.BaseType
-	   (Ast.ShortIntType,[P.clt2mcode "short" ty1;P.clt2mcode "int" ty2])) }
+    { Ast0_cocci.wrap
+	(Ast0_cocci.BaseType
+	   (Ast_cocci.ShortIntType,[P.clt2mcode "short" ty1;P.clt2mcode "int" ty2])) }
 | ty=Tint
-    { Ast0.wrap(Ast0.BaseType(Ast.IntType,[P.clt2mcode "int" ty])) }
+    { Ast0_cocci.wrap(Ast0_cocci.BaseType(Ast_cocci.IntType,[P.clt2mcode "int" ty])) }
 | p=TMetaType
     { let (nm,cstr,pure,clt) = p in
-      Ast0.wrap(Ast0.MetaType(P.clt2mcode nm clt,cstr,pure)) }
+      Ast0_cocci.wrap(Ast0_cocci.MetaType(P.clt2mcode nm clt,cstr,pure)) }
 | ty1=Tlong
-    { Ast0.wrap(Ast0.BaseType(Ast.LongType,[P.clt2mcode "long" ty1])) }
+    { Ast0_cocci.wrap(Ast0_cocci.BaseType(Ast_cocci.LongType,[P.clt2mcode "long" ty1])) }
 | ty1=Tlong ty2=Tint
-    { Ast0.wrap
-	(Ast0.BaseType
-	   (Ast.LongIntType,[P.clt2mcode "long" ty1;P.clt2mcode "int" ty2])) }
+    { Ast0_cocci.wrap
+	(Ast0_cocci.BaseType
+	   (Ast_cocci.LongIntType,[P.clt2mcode "long" ty1;P.clt2mcode "int" ty2])) }
 | ty1=Tlong ty2=Tlong
-    { Ast0.wrap
-	(Ast0.BaseType
-	   (Ast.LongLongType,
+    { Ast0_cocci.wrap
+	(Ast0_cocci.BaseType
+	   (Ast_cocci.LongLongType,
 	    [P.clt2mcode "long" ty1;P.clt2mcode "long" ty2])) }
 | ty1=Tlong ty2=Tlong ty3=Tint
-    { Ast0.wrap
-	(Ast0.BaseType
-	   (Ast.LongLongIntType,
+    { Ast0_cocci.wrap
+	(Ast0_cocci.BaseType
+	   (Ast_cocci.LongLongIntType,
 	    [P.clt2mcode "long" ty1;P.clt2mcode "long" ty2;
 	      P.clt2mcode "int" ty3])) }
 
@@ -958,79 +960,79 @@ signable_types:
     { let nm = (r,P.id2name p) in
     (* this is only possible when we are in a metavar decl.  Otherwise,
        it will be represented already as a MetaType *)
-    let _ = P.check_meta(Ast.MetaTypeDecl(Ast.NONE,nm)) in
-    Ast0.wrap(Ast0.MetaType(P.clt2mcode nm (P.id2clt p),Ast.CstrTrue,
-			    Ast0.Impure (*will be ignored*))) }
+    let _ = P.check_meta(Ast_cocci.MetaTypeDecl(Ast_cocci.NONE,nm)) in
+    Ast0_cocci.wrap(Ast0_cocci.MetaType(P.clt2mcode nm (P.id2clt p),Ast_cocci.CstrTrue,
+			    Ast0_cocci.Impure (*will be ignored*))) }
 
 non_signable_types_no_ident:
   ty=Tvoid
-    { Ast0.wrap(Ast0.BaseType(Ast.VoidType,[P.clt2mcode "void" ty])) }
+    { Ast0_cocci.wrap(Ast0_cocci.BaseType(Ast_cocci.VoidType,[P.clt2mcode "void" ty])) }
 | ty1=Tlong ty2=Tdouble
-    { Ast0.wrap
-	(Ast0.BaseType
-	   (Ast.LongDoubleType,
+    { Ast0_cocci.wrap
+	(Ast0_cocci.BaseType
+	   (Ast_cocci.LongDoubleType,
 	    [P.clt2mcode "long" ty1;P.clt2mcode "double" ty2])) }
 | ty=Tdouble
-    { Ast0.wrap(Ast0.BaseType(Ast.DoubleType,[P.clt2mcode "double" ty])) }
+    { Ast0_cocci.wrap(Ast0_cocci.BaseType(Ast_cocci.DoubleType,[P.clt2mcode "double" ty])) }
 | ty=Tfloat
-    { Ast0.wrap(Ast0.BaseType(Ast.FloatType,[P.clt2mcode "float" ty])) }
+    { Ast0_cocci.wrap(Ast0_cocci.BaseType(Ast_cocci.FloatType,[P.clt2mcode "float" ty])) }
 | ty1=Tlong ty=Tdouble c=Tcomplex
-    { Ast0.wrap
-	(Ast0.BaseType
-	   (Ast.LongDoubleComplexType,
+    { Ast0_cocci.wrap
+	(Ast0_cocci.BaseType
+	   (Ast_cocci.LongDoubleComplexType,
 	    [P.clt2mcode "long" ty1;P.clt2mcode "double" ty;
 	      P.clt2mcode "complex" c])) }
 | ty=Tdouble c=Tcomplex
-    { Ast0.wrap
-	(Ast0.BaseType
-	   (Ast.DoubleComplexType,
+    { Ast0_cocci.wrap
+	(Ast0_cocci.BaseType
+	   (Ast_cocci.DoubleComplexType,
 	    [P.clt2mcode "double" ty;P.clt2mcode "complex" c])) }
 | ty=Tfloat c=Tcomplex
-    { Ast0.wrap
-	(Ast0.BaseType
-	   (Ast.FloatComplexType,
+    { Ast0_cocci.wrap
+	(Ast0_cocci.BaseType
+	   (Ast_cocci.FloatComplexType,
 	    [P.clt2mcode "float" ty;P.clt2mcode "complex" c])) }
 | ty=Tsize_t
-    { Ast0.wrap(Ast0.BaseType(Ast.SizeType,[P.clt2mcode "size_t" ty])) }
+    { Ast0_cocci.wrap(Ast0_cocci.BaseType(Ast_cocci.SizeType,[P.clt2mcode "size_t" ty])) }
 | ty=Tssize_t
-    { Ast0.wrap(Ast0.BaseType(Ast.SSizeType,[P.clt2mcode "ssize_t" ty])) }
+    { Ast0_cocci.wrap(Ast0_cocci.BaseType(Ast_cocci.SSizeType,[P.clt2mcode "ssize_t" ty])) }
 | ty=Tptrdiff_t
-    { Ast0.wrap(Ast0.BaseType(Ast.PtrDiffType,[P.clt2mcode "ptrdiff_t" ty])) }
+    { Ast0_cocci.wrap(Ast0_cocci.BaseType(Ast_cocci.PtrDiffType,[P.clt2mcode "ptrdiff_t" ty])) }
 | s=Tenum i=ident
-    { Ast0.wrap(Ast0.EnumName(P.clt2mcode "enum" s, Some i)) }
+    { Ast0_cocci.wrap(Ast0_cocci.EnumName(P.clt2mcode "enum" s, Some i)) }
 | s=Tenum i=ioption(ident) l=TOBrace ids=enum_decl_list r=TCBrace
     { (if i = None && !Data.in_iso
     then failwith "enums must be named in the iso file");
-      Ast0.wrap(Ast0.EnumDef(Ast0.wrap(Ast0.EnumName(P.clt2mcode "enum" s, i)),
+      Ast0_cocci.wrap(Ast0_cocci.EnumDef(Ast0_cocci.wrap(Ast0_cocci.EnumName(P.clt2mcode "enum" s, i)),
 			     P.clt2mcode "{" l, ids, P.clt2mcode "}" r)) }
 | s=struct_or_union i=type_ident // allow typedef name
-    { Ast0.wrap(Ast0.StructUnionName(s, Some i)) }
+    { Ast0_cocci.wrap(Ast0_cocci.StructUnionName(s, Some i)) }
 | s=struct_or_union i=ioption(type_ident)
     l=TOBrace d=struct_decl_list r=TCBrace
     { (if i = None && !Data.in_iso
     then failwith "structures must be named in the iso file");
-      Ast0.wrap(Ast0.StructUnionDef(Ast0.wrap(Ast0.StructUnionName(s, i)),
+      Ast0_cocci.wrap(Ast0_cocci.StructUnionDef(Ast0_cocci.wrap(Ast0_cocci.StructUnionName(s, i)),
 				    P.clt2mcode "{" l,
 				    d, P.clt2mcode "}" r)) }
 | s=TMetaType l=TOBrace d=struct_decl_list r=TCBrace
     { let (nm,cstr,pure,clt) = s in
-    let ty = Ast0.wrap(Ast0.MetaType(P.clt2mcode nm clt,cstr,pure)) in
-    Ast0.wrap(Ast0.StructUnionDef(ty,P.clt2mcode "{" l,d,P.clt2mcode "}" r)) }
+    let ty = Ast0_cocci.wrap(Ast0_cocci.MetaType(P.clt2mcode nm clt,cstr,pure)) in
+    Ast0_cocci.wrap(Ast0_cocci.StructUnionDef(ty,P.clt2mcode "{" l,d,P.clt2mcode "}" r)) }
 | Tdecimal TOPar enum_val TComma enum_val TCPar
-    { Ast0.wrap(Ast0.Decimal(P.clt2mcode "decimal" $1,
+    { Ast0_cocci.wrap(Ast0_cocci.Decimal(P.clt2mcode "decimal" $1,
 			     P.clt2mcode "(" $2,$3,
 			     Some (P.clt2mcode "," $4), Some $5,
 			     P.clt2mcode ")" $6)) }
 | Tdecimal TOPar enum_val TCPar
-    { Ast0.wrap(Ast0.Decimal(P.clt2mcode "decimal" $1,
+    { Ast0_cocci.wrap(Ast0_cocci.Decimal(P.clt2mcode "decimal" $1,
 			     P.clt2mcode "(" $2,$3,None,None,
 			     P.clt2mcode ")" $4)) }
 | TTypeof TOPar eexpr TCPar
-    { Ast0.wrap(Ast0.TypeOfExpr(P.clt2mcode "typeof" $1,
+    { Ast0_cocci.wrap(Ast0_cocci.TypeOfExpr(P.clt2mcode "typeof" $1,
                                    P.clt2mcode "(" $2,$3,
                                    P.clt2mcode ")" $4)) }
 | TTypeof TOPar ctype TCPar
-    { Ast0.wrap(Ast0.TypeOfType(P.clt2mcode "typeof" $1,
+    { Ast0_cocci.wrap(Ast0_cocci.TypeOfType(P.clt2mcode "typeof" $1,
                                    P.clt2mcode "(" $2,$3,
                                    P.clt2mcode ")" $4)) }
 | TautoType
@@ -1043,7 +1045,7 @@ non_signable_types_no_ident:
        | On (Some i) -> i >= 2011
      in
      if can_auto_type
-     then Ast0.wrap(Ast0.AutoType(P.clt2mcode "auto" $1))
+     then Ast0_cocci.wrap(Ast0_cocci.AutoType(P.clt2mcode "auto" $1))
      else
        raise
          (Semantic_cocci.Semantic
@@ -1052,13 +1054,13 @@ non_signable_types_no_ident:
 non_signable_types:
   ty=non_signable_types_no_ident { ty }
 | p=TTypeId
-    { Ast0.wrap(Ast0.TypeName(P.id2mcode p)) }
+    { Ast0_cocci.wrap(Ast0_cocci.TypeName(P.id2mcode p)) }
 
 signed_basic_types:
   r=Tsigned ty=signable_types
-    { Ast0.wrap(Ast0.Signed(P.clt2mcode Ast.Signed r,Some ty)) }
+    { Ast0_cocci.wrap(Ast0_cocci.Signed(P.clt2mcode Ast_cocci.Signed r,Some ty)) }
 | r=Tunsigned ty=signable_types
-    { Ast0.wrap(Ast0.Signed(P.clt2mcode Ast.Unsigned r,Some ty)) }
+    { Ast0_cocci.wrap(Ast0_cocci.Signed(P.clt2mcode Ast_cocci.Unsigned r,Some ty)) }
 
 all_basic_types:
   ty=signed_basic_types { ty }
@@ -1071,11 +1073,11 @@ all_basic_types_no_ident:
 | ty=non_signable_types { ty }
 
 signed_or_unsigned:
-| r=Tsigned { Ast0.wrap(Ast0.Signed(P.clt2mcode Ast.Signed r,None)) }
-| r=Tunsigned { Ast0.wrap(Ast0.Signed(P.clt2mcode Ast.Unsigned r,None)) }
+| r=Tsigned { Ast0_cocci.wrap(Ast0_cocci.Signed(P.clt2mcode Ast_cocci.Signed r,None)) }
+| r=Tunsigned { Ast0_cocci.wrap(Ast0_cocci.Signed(P.clt2mcode Ast_cocci.Unsigned r,None)) }
 
 top_ctype:
-  ctype { Ast0.wrap(Ast0.OTHER(Ast0.wrap(Ast0.Ty($1)))) }
+  ctype { Ast0_cocci.wrap(Ast0_cocci.OTHER(Ast0_cocci.wrap(Ast0_cocci.Ty($1)))) }
 
 ctype:
   cv=ioption(const_vol) ty=all_basic_types m=list(mul)
@@ -1087,12 +1089,12 @@ ctype:
 | cv=ioption(const_vol) ty=signed_or_unsigned { P.make_cv cv ty }
 | lp=TOPar0 t=midzero_list(ctype,ctype) rp=TCPar0
     { let (mids,code) = t in
-      Ast0.wrap
-	(Ast0.DisjType(P.id2mcode lp,code,mids, P.id2mcode rp)) }
+      Ast0_cocci.wrap
+	(Ast0_cocci.DisjType(P.id2mcode lp,code,mids, P.id2mcode rp)) }
 | lp=TOPar0 t=andzero_list(ctype,ctype) rp=TCPar0
     { let (mids,code) = t in
-      Ast0.wrap
-	(Ast0.ConjType(P.id2mcode lp,code,mids, P.id2mcode rp)) }
+      Ast0_cocci.wrap
+	(Ast0_cocci.ConjType(P.id2mcode lp,code,mids, P.id2mcode rp)) }
 
 mul: a=TMul b=ioption(const_vol) { (a,b) }
 
@@ -1106,15 +1108,15 @@ typedef_ctype:
     { P.pointerify (P.make_cv cv ty) m }
 | lp=TOPar0 t=midzero_list(mctype,mctype) rp=TCPar0
     { let (mids,code) = t in
-      Ast0.wrap
-	(Ast0.DisjType(P.id2mcode lp,code,mids, P.id2mcode rp)) }
+      Ast0_cocci.wrap
+	(Ast0_cocci.DisjType(P.id2mcode lp,code,mids, P.id2mcode rp)) }
 | TMeta { tmeta_to_type $1 }
 
 /* ---------------------------------------------------------------------- */
 
 struct_or_union:
-       s=Tstruct { P.clt2mcode Ast.Struct s }
-     | u=Tunion  { P.clt2mcode Ast.Union u }
+       s=Tstruct { P.clt2mcode Ast_cocci.Struct s }
+     | u=Tunion  { P.clt2mcode Ast_cocci.Union u }
 
 struct_decl:
       TNothing        { [] }
@@ -1126,28 +1128,28 @@ struct_decl_one:
     | TMeta { tmeta_to_field $1 }
     | lp=TOPar0 t=midzero_list(struct_decl_one,struct_decl_one) rp=TCPar0
 	{ let (mids,code) = t in
-	Ast0.wrap
-	  (Ast0.DisjField(P.id2mcode lp,code,mids, P.id2mcode rp)) }
+	Ast0_cocci.wrap
+	  (Ast0_cocci.DisjField(P.id2mcode lp,code,mids, P.id2mcode rp)) }
     | lp=TOPar0 t=andzero_list(struct_decl_one,struct_decl_one) rp=TCPar0
 	{ let (mids,code) = t in
-	Ast0.wrap
-	  (Ast0.ConjField(P.id2mcode lp,code,mids, P.id2mcode rp)) }
+	Ast0_cocci.wrap
+	  (Ast0_cocci.ConjField(P.id2mcode lp,code,mids, P.id2mcode rp)) }
     | t=ctype d=direct_decl_option(disj_ident) bf=struct_bitfield? pv=TPtVirg
 	 { let (id,fn) = d in
-	 Ast0.wrap(Ast0.Field(fn t,id,bf,P.clt2mcode ";" pv)) }
+	 Ast0_cocci.wrap(Ast0_cocci.Field(fn t,id,bf,P.clt2mcode ";" pv)) }
     | cv=ioption(const_vol) i=pure_ident_or_symbol
       d=direct_decl_option(disj_ident)
 	 bf=struct_bitfield?
 	 pv=TPtVirg
 	 { let (id,fn) = d in
-	 let idtype = P.make_cv cv (Ast0.wrap (Ast0.TypeName(P.id2mcode i))) in
-	 Ast0.wrap(Ast0.Field(fn idtype,id,bf,P.clt2mcode ";" pv)) }
+	 let idtype = P.make_cv cv (Ast0_cocci.wrap (Ast0_cocci.TypeName(P.id2mcode i))) in
+	 Ast0_cocci.wrap(Ast0_cocci.Field(fn idtype,id,bf,P.clt2mcode ";" pv)) }
 
 struct_bitfield:
    c=TDotDot e=expr { (P.clt2mcode ":" c, e) }
 
 struct_decl_list:
-   struct_decl_list_start { Ast0.wrap $1 }
+   struct_decl_list_start { Ast0_cocci.wrap $1 }
 
 struct_decl_list_start:
   /* empty */                        { [] }
@@ -1161,37 +1163,37 @@ struct_decl_list_start:
 /* very restricted what kinds of expressions can appear in an enum decl */
 
 enum_decl_one:
-    | disj_ident    { Ast0.wrap(Ast0.Enum($1, None)) }
+    | disj_ident    { Ast0_cocci.wrap(Ast0_cocci.Enum($1, None)) }
     | disj_ident TEq enum_val
 	{
-	Ast0.wrap
-	  (Ast0.Enum
+	Ast0_cocci.wrap
+	  (Ast0_cocci.Enum
 	     ($1, Some(P.clt2mcode "=" $2, $3))) }
 
 enum_val:
-   ident    { Ast0.wrap(Ast0.Ident($1)) }
+   ident    { Ast0_cocci.wrap(Ast0_cocci.Ident($1)) }
  | TInt
      { let (x,clt) = $1 in
-     Ast0.wrap(Ast0.Constant (P.clt2mcode (Ast.Int x) clt)) }
+     Ast0_cocci.wrap(Ast0_cocci.Constant (P.clt2mcode (Ast_cocci.Int x) clt)) }
  | TMeta { tmeta_to_exp $1 }
  | TMetaConst
      { let (nm,constraints,pure,ty,clt) = $1 in
-     Ast0.wrap
-       (Ast0.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast.CONST,pure,None)) }
+     Ast0_cocci.wrap
+       (Ast0_cocci.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast_cocci.CONST,pure,None)) }
  | TMetaExp
      { let (nm,constraints,pure,ty,clt,bitfield) = $1 in
      let bitfield' = Common.map_option (P.dolen clt) bitfield in
-     Ast0.wrap
-       (Ast0.MetaExpr
-	  (P.clt2mcode nm clt,constraints,ty,Ast.ANY,pure,bitfield')) }
+     Ast0_cocci.wrap
+       (Ast0_cocci.MetaExpr
+	  (P.clt2mcode nm clt,constraints,ty,Ast_cocci.ANY,pure,bitfield')) }
  | TMetaIdExp
      { let (nm,constraints,pure,ty,clt) = $1 in
-     Ast0.wrap
-       (Ast0.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast.ID,pure,None)) }
+     Ast0_cocci.wrap
+       (Ast0_cocci.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast_cocci.ID,pure,None)) }
 
 enum_decl_list:
    nonempty_list_start(enum_decl_one,edots_when(TEllipsis,enum_decl_one))
-     { Ast0.wrap($1 P.mkenumdots (fun c -> Ast0.EnumComma c)) }
+     { Ast0_cocci.wrap($1 P.mkenumdots (fun c -> Ast0_cocci.EnumComma c)) }
 
 /*****************************************************************************/
 
@@ -1256,96 +1258,96 @@ plus_id_body:
 
 filespec:
   TMinusFile TPlusFile
-    { [Ast0.wrap
-	  (Ast0.FILEINFO(P.id2mcode $1,
+    { [Ast0_cocci.wrap
+	  (Ast0_cocci.FILEINFO(P.id2mcode $1,
 			 P.id2mcode $2))] }
 
 includes:
   TIncludeL
-    { Ast0.wrap
-	(Ast0.Include(P.clt2mcode "#include"
+    { Ast0_cocci.wrap
+	(Ast0_cocci.Include(P.clt2mcode "#include"
 			(P.drop_pos (P.drop_aft (P.id2clt $1))),
 		      let (arity,ln,lln,llne,offset,col,strbef,straft,pos,_) =
 			P.id2clt $1 in
 		      let clt = (* default to one space whitespace *)
 			(arity,ln,lln,llne,offset,0,strbef,straft,pos," ") in
 		      P.clt2mcode
-			(Ast.Local (Parse_aux.str2inc (P.id2name $1)))
+			(Ast_cocci.Local (Parse_aux.str2inc (P.id2name $1)))
 			(P.drop_bef clt))) }
 | TIncludeNL
-    { Ast0.wrap
-	(Ast0.Include(P.clt2mcode "#include"
+    { Ast0_cocci.wrap
+	(Ast0_cocci.Include(P.clt2mcode "#include"
 			(P.drop_pos (P.drop_aft (P.id2clt $1))),
 		      let (arity,ln,lln,llne,offset,col,strbef,straft,pos,_) =
 			P.id2clt $1 in
 		      let clt = (* default to one space whitespace *)
 			(arity,ln,lln,llne,offset,0,strbef,straft,pos," ") in
 		      P.clt2mcode
-			(Ast.NonLocal (Parse_aux.str2inc (P.id2name $1)))
+			(Ast_cocci.NonLocal (Parse_aux.str2inc (P.id2name $1)))
 			(P.drop_bef clt))) }
 | TIncludeAny
-    { Ast0.wrap
-	(Ast0.Include(P.clt2mcode "#include"
+    { Ast0_cocci.wrap
+	(Ast0_cocci.Include(P.clt2mcode "#include"
 			(P.drop_pos (P.drop_aft (P.id2clt $1))),
 		      let (arity,ln,lln,llne,offset,col,strbef,straft,pos,_) =
 			P.id2clt $1 in
 		      let clt = (* default to one space whitespace *)
 			(arity,ln,lln,llne,offset,0,strbef,straft,pos," ") in
-		      P.clt2mcode Ast.AnyInc (P.drop_bef clt))) }
+		      P.clt2mcode Ast_cocci.AnyInc (P.drop_bef clt))) }
 | TInclude TMetaExp
-     { Ast0.wrap
-	 (Ast0.MetaInclude
+     { Ast0_cocci.wrap
+	 (Ast0_cocci.MetaInclude
 	    (P.clt2mcode "#include" $1,
 	     match $2 with
 	       (nm,constraints,pure,ty,clt,None) ->
-		 Ast0.wrap
-		   (Ast0.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast.CONST,
+		 Ast0_cocci.wrap
+		   (Ast0_cocci.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast_cocci.CONST,
 				  pure,None))
 	     | _ -> failwith "length not allowed for include argument")) }
 
 | TUndef TLineEnd
     { let (clt,ident) = $1 in
       let aft = P.get_aft clt in (* move stuff after the define to the ident *)
-      Ast0.wrap
-      (Ast0.Undef
+      Ast0_cocci.wrap
+      (Ast0_cocci.Undef
 	 (P.clt2mcode "#undef" (P.drop_aft clt),
 	  (match ident with
 	    TMetaId((nm,constraints,seed,pure,clt)) ->
 	      let clt = P.set_aft aft clt in
-	      Ast0.wrap(Ast0.MetaId(P.clt2mcode nm clt,constraints,seed,pure))
+	      Ast0_cocci.wrap(Ast0_cocci.MetaId(P.clt2mcode nm clt,constraints,seed,pure))
 	  | TIdent((nm,clt)) ->
 	      let clt = P.set_aft aft clt in
-	      Ast0.wrap(Ast0.Id(P.clt2mcode nm clt))
+	      Ast0_cocci.wrap(Ast0_cocci.Id(P.clt2mcode nm clt))
 	  | TSymId(nm,clt) ->
 	      let clt = P.set_aft aft clt in
-	      Ast0.wrap(Ast0.Id(P.clt2mcode nm clt))
+	      Ast0_cocci.wrap(Ast0_cocci.Id(P.clt2mcode nm clt))
 	  | _ ->
 	      raise
 		(Semantic_cocci.Semantic
 		   "unexpected name for a #define")))) }
 | d=defineop TLineEnd
-    { d (Ast0.wrap []) }
+    { d (Ast0_cocci.wrap []) }
 | d=defineop t=ctype TLineEnd
-    { let ty = Ast0.wrap(Ast0.TopExp(Ast0.wrap(Ast0.TypeExp(t)))) in
-      d (Ast0.wrap [ty]) }
+    { let ty = Ast0_cocci.wrap(Ast0_cocci.TopExp(Ast0_cocci.wrap(Ast0_cocci.TypeExp(t)))) in
+      d (Ast0_cocci.wrap [ty]) }
 | defineop b=toplevel_seq_start(toplevel_after_dots) TLineEnd
     { let body =
 	match b with
 	  [e] ->
-	    (match Ast0.unwrap e with
-	      Ast0.Exp(e1) ->
-		[Ast0.rewrap e (Ast0.TopExp(Ast0.set_arg_exp (e1)))]
+	    (match Ast0_cocci.unwrap e with
+	      Ast0_cocci.Exp(e1) ->
+		[Ast0_cocci.rewrap e (Ast0_cocci.TopExp(Ast0_cocci.set_arg_exp (e1)))]
 	    | _ -> b)
 	| _ -> b in
-      $1 (Ast0.wrap body) }
+      $1 (Ast0_cocci.wrap body) }
 | TPragma TLineEnd
     { let (clt,ident,rest,rest_clt) = $1 in
       let aft = P.get_aft clt in (* move stuff after the pragma to the ident *)
       let body =
       if rest = "..."
-      then Ast0.wrap(Ast0.PragmaDots(P.clt2mcode "..." rest_clt))
-      else Ast0.wrap(Ast0.PragmaString(P.clt2mcode rest rest_clt)) in
-      Ast0.wrap(Ast0.Pragma(P.clt2mcode "#pragma" clt, inline_id aft ident,
+      then Ast0_cocci.wrap(Ast0_cocci.PragmaDots(P.clt2mcode "..." rest_clt))
+      else Ast0_cocci.wrap(Ast0_cocci.PragmaString(P.clt2mcode rest rest_clt)) in
+      Ast0_cocci.wrap(Ast0_cocci.Pragma(P.clt2mcode "#pragma" clt, inline_id aft ident,
 			    body)) }
 
 defineop:
@@ -1353,10 +1355,10 @@ defineop:
     { let (clt,ident) = $1 in
       let aft = P.get_aft clt in (* move stuff after the define to the ident *)
       function body ->
-	Ast0.wrap
-	  (Ast0.Define
+	Ast0_cocci.wrap
+	  (Ast0_cocci.Define
 	     (P.clt2mcode "#define" (P.drop_aft clt), inline_id aft ident,
-	      Ast0.wrap Ast0.NoParams,body)) }
+	      Ast0_cocci.wrap Ast0_cocci.NoParams,body)) }
 | TDefineParam define_param_list_option TCPar
     { let (clt,ident,parenoff,parencol) = $1 in
       let aft = P.get_aft clt in (* move stuff after the define to the ( *)
@@ -1366,35 +1368,35 @@ defineop:
 	P.clt2mcode "("
 	  (arity,line,lline,llineend,parenoff,parencol,[],[],[],"") in
       function body ->
-	Ast0.wrap
-	  (Ast0.Define
+	Ast0_cocci.wrap
+	  (Ast0_cocci.Define
 	     (P.clt2mcode "#define" (P.drop_aft clt),
 	      (match ident with
 		TMetaId((nm,constraints,seed,pure,clt)) ->
-		  Ast0.wrap
-		    (Ast0.MetaId(P.clt2mcode nm clt,constraints,seed,pure))
+		  Ast0_cocci.wrap
+		    (Ast0_cocci.MetaId(P.clt2mcode nm clt,constraints,seed,pure))
 	      | TIdent((nm,clt)) ->
-		  Ast0.wrap(Ast0.Id(P.clt2mcode nm clt))
+		  Ast0_cocci.wrap(Ast0_cocci.Id(P.clt2mcode nm clt))
 	      | TSymId(nm,clt) ->
-		  Ast0.wrap(Ast0.Id(P.clt2mcode nm clt))
+		  Ast0_cocci.wrap(Ast0_cocci.Id(P.clt2mcode nm clt))
 	      | _ ->
 		  raise
 		    (Semantic_cocci.Semantic
 		       "unexpected name for a #define")),
 	      (let clt = P.set_aft aft $3 in
-	      Ast0.wrap (Ast0.DParams (lp,$2,P.clt2mcode ")" clt))),body)) }
+	      Ast0_cocci.wrap (Ast0_cocci.DParams (lp,$2,P.clt2mcode ")" clt))),body)) }
 
 /* ---------------------------------------------------------------------- */
 
-dparam: mident { Ast0.wrap(Ast0.DParam $1) }
+dparam: mident { Ast0_cocci.wrap(Ast0_cocci.DParam $1) }
 | TMetaDParamList { P.meta_dparam_list $1 }
 
 define_param_list_option:
     empty_list_start(dparam,TEllipsis)
-      { Ast0.wrap
+      { Ast0_cocci.wrap
 	  ($1
-	     (fun _ d -> Ast0.wrap(Ast0.DPdots(P.clt2mcode "..." d)))
-	     (fun c -> Ast0.DPComma c)) }
+	     (fun _ d -> Ast0_cocci.wrap(Ast0_cocci.DPdots(P.clt2mcode "..." d)))
+	     (fun c -> Ast0_cocci.DPComma c)) }
 
 /*****************************************************************************/
 
@@ -1403,7 +1405,7 @@ define_param_list_option:
 arg_list(arg):
   arglist=separated_llist(TComma, argorellipsis(one_arg(arg)))
      { let (args,vararg) = cleanup_arglist arglist in
-       ((Ast0.wrap args), vararg) }
+       ((Ast0_cocci.wrap args), vararg) }
 
 argorellipsis(arg):
   arg=arg { Arg arg }
@@ -1416,7 +1418,7 @@ one_arg(arg):
     { let (nm,lenname,cstr,pure,clt) = metaparamlist in
       let nm = P.clt2mcode nm clt in
       let lenname = P.dolen clt lenname in
-      Ast0.wrap(Ast0.MetaParamList(nm,lenname,cstr,pure)) }
+      Ast0_cocci.wrap(Ast0_cocci.MetaParamList(nm,lenname,cstr,pure)) }
 
 %inline separated_llist(separator, X):
   xs = reverse_separated_llist(separator, X)
@@ -1439,27 +1441,27 @@ funproto:
   s=ioption(storage) i=ioption(Tinline) t=ctype
   TFunProto id=fn_ident
   lp=TOPar arglist=arg_list(name_opt_decl) rp=TCPar pt=TPtVirg
-      { let s = match s with None -> [] | Some s -> [Ast0.FStorage s] in
+      { let s = match s with None -> [] | Some s -> [Ast0_cocci.FStorage s] in
         let i =
 	  match i with
 	    None -> []
-	  | Some i -> [Ast0.FInline (P.clt2mcode "inline" i)] in
-	let t = [Ast0.FType t] in
+	  | Some i -> [Ast0_cocci.FInline (P.clt2mcode "inline" i)] in
+	let t = [Ast0_cocci.FType t] in
         let (args,vararg) = arglist in
-	Ast0.wrap
-	  (Ast0.FunProto
+	Ast0_cocci.wrap
+	  (Ast0_cocci.FunProto
 	     (s @ i @ t, id,
 	      P.clt2mcode "(" lp, args, vararg, P.clt2mcode ")" rp,
 	      P.clt2mcode ";" pt)) }
 | i=Tinline s=storage t=ctype
   TFunProto id=fn_ident
   lp=TOPar arglist=arg_list(name_opt_decl) rp=TCPar pt=TPtVirg
-      { let s = [Ast0.FStorage s] in
-        let i = [Ast0.FInline (P.clt2mcode "inline" i)] in
-	let t = [Ast0.FType t] in
+      { let s = [Ast0_cocci.FStorage s] in
+        let i = [Ast0_cocci.FInline (P.clt2mcode "inline" i)] in
+	let t = [Ast0_cocci.FType t] in
         let (args,vararg) = arglist in
-	Ast0.wrap
-	  (Ast0.FunProto
+	Ast0_cocci.wrap
+	  (Ast0_cocci.FunProto
 	     (s @ i @ t, id,
 	      P.clt2mcode "(" lp, args, vararg, P.clt2mcode ")" rp,
 	      P.clt2mcode ";" pt)) }
@@ -1473,55 +1475,55 @@ single_fundecl:
   TFunDecl i=fn_ident lp=TOPar arglist=arg_list(decl) rp=TCPar
   lb=TOBrace b=fun_start rb=TCBrace
       { let (args,vararg) = arglist in
-        Ast0.wrap(Ast0.FunDecl((Ast0.default_info(),Ast0.context_befaft()),
+        Ast0_cocci.wrap(Ast0_cocci.FunDecl((Ast0_cocci.default_info(),Ast0_cocci.context_befaft()),
 			       f, i,
 			       P.clt2mcode "(" (lp), args, vararg,
 			       P.clt2mcode ")" rp,
 			       P.clt2mcode "{" lb, b,
 			       P.clt2mcode "}" rb,
-			       (Ast0.default_info(),Ast0.context_befaft()))) }
+			       (Ast0_cocci.default_info(),Ast0_cocci.context_befaft()))) }
 
 fninfo:
     /* empty */ { [] }
   | storage  fninfo
       { try
 	let _ =
-	  List.find (function Ast0.FStorage(_) -> true | _ -> false) $2 in
+	  List.find (function Ast0_cocci.FStorage(_) -> true | _ -> false) $2 in
 	raise (Semantic_cocci.Semantic "duplicate storage")
-      with Not_found -> (Ast0.FStorage($1))::$2 }
-  | t=ctype r=fninfo_nt { (Ast0.FType(t))::r }
+      with Not_found -> (Ast0_cocci.FStorage($1))::$2 }
+  | t=ctype r=fninfo_nt { (Ast0_cocci.FType(t))::r }
   | Tinline  fninfo
       { try
-	let _ = List.find (function Ast0.FInline(_) -> true | _ -> false) $2 in
+	let _ = List.find (function Ast0_cocci.FInline(_) -> true | _ -> false) $2 in
 	raise (Semantic_cocci.Semantic "duplicate inline")
-      with Not_found -> (Ast0.FInline(P.clt2mcode "inline" $1))::$2 }
+      with Not_found -> (Ast0_cocci.FInline(P.clt2mcode "inline" $1))::$2 }
   | Tattr    fninfo
       { try
-	let _ = List.find (function Ast0.FAttr(_) -> true | _ -> false) $2 in
+	let _ = List.find (function Ast0_cocci.FAttr(_) -> true | _ -> false) $2 in
 	raise (Semantic_cocci.Semantic "multiple attributes")
-      with Not_found -> (Ast0.FAttr(P.id2mcode $1))::$2 }
+      with Not_found -> (Ast0_cocci.FAttr(P.id2mcode $1))::$2 }
 
 fninfo_nt:
     /* empty */ { [] }
   | storage  fninfo_nt
       { try
 	let _ =
-	  List.find (function Ast0.FStorage(_) -> true | _ -> false) $2 in
+	  List.find (function Ast0_cocci.FStorage(_) -> true | _ -> false) $2 in
 	raise (Semantic_cocci.Semantic "duplicate storage")
-      with Not_found -> (Ast0.FStorage($1))::$2 }
+      with Not_found -> (Ast0_cocci.FStorage($1))::$2 }
   | Tinline  fninfo_nt
       { try
-	let _ = List.find (function Ast0.FInline(_) -> true | _ -> false) $2 in
+	let _ = List.find (function Ast0_cocci.FInline(_) -> true | _ -> false) $2 in
 	raise (Semantic_cocci.Semantic "duplicate inline")
-      with Not_found -> (Ast0.FInline(P.clt2mcode "inline" $1))::$2 }
+      with Not_found -> (Ast0_cocci.FInline(P.clt2mcode "inline" $1))::$2 }
   | Tattr    fninfo_nt
       { try
-	let _ = List.find (function Ast0.FAttr(_) -> true | _ -> false) $2 in
+	let _ = List.find (function Ast0_cocci.FAttr(_) -> true | _ -> false) $2 in
 	raise (Semantic_cocci.Semantic "duplicate init")
-      with Not_found -> (Ast0.FAttr(P.id2mcode $1))::$2 }
+      with Not_found -> (Ast0_cocci.FAttr(P.id2mcode $1))::$2 }
 
 storage:
-         s=Tstatic      { P.clt2mcode Ast.Static s }
+         s=Tstatic      { P.clt2mcode Ast_cocci.Static s }
        | s=Tauto
            {
             let can_auto_storage =
@@ -1531,30 +1533,30 @@ storage:
               | On (Some i) -> i < 2011
             in
             if can_auto_storage
-            then P.clt2mcode Ast.Auto s
+            then P.clt2mcode Ast_cocci.Auto s
             else
               raise
                 (Semantic_cocci.Semantic
                   "auto is not a valid storage since C++11, \
                    try removing the version specification on the --c++ option \
                    or removing the whole option") }
-       | s=Tregister    { P.clt2mcode Ast.Register s }
-       | s=Textern      { P.clt2mcode Ast.Extern s }
+       | s=Tregister    { P.clt2mcode Ast_cocci.Register s }
+       | s=Textern      { P.clt2mcode Ast_cocci.Extern s }
 
 decl: t=ctype d=direct_declarator(disj_ident)
-	{ let (i,fn) = d in Ast0.wrap(Ast0.Param(fn t, Some i)) }
-    | t=ctype { (*verify in FunDecl*) Ast0.wrap(Ast0.Param(t, None)) }
+	{ let (i,fn) = d in Ast0_cocci.wrap(Ast0_cocci.Param(fn t, Some i)) }
+    | t=ctype { (*verify in FunDecl*) Ast0_cocci.wrap(Ast0_cocci.Param(t, None)) }
     | TMetaParam
 	{ let (nm,cstr,pure,clt) = $1 in
-	Ast0.wrap(Ast0.MetaParam(P.clt2mcode nm clt,cstr,pure)) }
+	Ast0_cocci.wrap(Ast0_cocci.MetaParam(P.clt2mcode nm clt,cstr,pure)) }
     | TMeta { tmeta_to_param $1 }
 
 name_opt_decl:
       decl  { $1 }
 
 const_vol:
-      Tconst       { P.clt2mcode Ast.Const $1 }
-    | Tvolatile    { P.clt2mcode Ast.Volatile $1 }
+      Tconst       { P.clt2mcode Ast_cocci.Const $1 }
+    | Tvolatile    { P.clt2mcode Ast_cocci.Volatile $1 }
 
 /*****************************************************************************/
 
@@ -1592,30 +1594,30 @@ statement:
 | TOBrace fun_start TCBrace
     { P.seq $1 $2 $3 }
 | Texec TIdent exec_list TPtVirg
-    { Ast0.wrap(
-      Ast0.Exec(P.clt2mcode "EXEC" $1,P.clt2mcode (fst $2) (snd $2),
-		Ast0.wrap $3,P.clt2mcode ";" $4)) }
+    { Ast0_cocci.wrap(
+      Ast0_cocci.Exec(P.clt2mcode "EXEC" $1,P.clt2mcode (fst $2) (snd $2),
+		Ast0_cocci.wrap $3,P.clt2mcode ";" $4)) }
 
 stm_dots:
   TEllipsis w=list(whenppdecs)
-    { Ast0.wrap(Ast0.Dots(P.clt2mcode "..." $1, List.concat w)) }
+    { Ast0_cocci.wrap(Ast0_cocci.Dots(P.clt2mcode "..." $1, List.concat w)) }
 | TOEllipsis w=list(whenppdecs) b=nest_start c=TCEllipsis
-    { Ast0.wrap(Ast0.Nest(P.clt2mcode "<..." $1, b,
+    { Ast0_cocci.wrap(Ast0_cocci.Nest(P.clt2mcode "<..." $1, b,
 			  P.clt2mcode "...>" c, List.concat w, false)) }
 | TPOEllipsis w=list(whenppdecs) b=nest_start c=TPCEllipsis
-    { Ast0.wrap(Ast0.Nest(P.clt2mcode "<+..." $1, b,
+    { Ast0_cocci.wrap(Ast0_cocci.Nest(P.clt2mcode "<+..." $1, b,
 			  P.clt2mcode "...+>" c, List.concat w, true)) }
 
 %inline stm_dots_ell:
   a=TEllipsis w=list(whenppdecs)
-    { Ast0.wrap(Ast0.Dots(P.clt2mcode "..." a, List.concat w)) }
+    { Ast0_cocci.wrap(Ast0_cocci.Dots(P.clt2mcode "..." a, List.concat w)) }
 
 %inline stm_dots_nest:
   a=TOEllipsis w=list(whenppdecs) b=nest_start c=TCEllipsis
-    { Ast0.wrap(Ast0.Nest(P.clt2mcode "<..." a, b,
+    { Ast0_cocci.wrap(Ast0_cocci.Nest(P.clt2mcode "<..." a, b,
 			  P.clt2mcode "...>" c, List.concat w, false)) }
 | a=TPOEllipsis w=list(whenppdecs) b=nest_start c=TPCEllipsis
-    { Ast0.wrap(Ast0.Nest(P.clt2mcode "<+..." a, b,
+    { Ast0_cocci.wrap(Ast0_cocci.Nest(P.clt2mcode "<+..." a, b,
 			  P.clt2mcode "...+>" c, List.concat w, true)) }
 
 whenppdecs: w=whens(when_start,rule_elem_statement,any_strict)
@@ -1625,7 +1627,7 @@ whenppdecs: w=whens(when_start,rule_elem_statement,any_strict)
 what about statement metavariables? */
 rule_elem_statement:
   one_decl_var
-    { Ast0.wrap(Ast0.Decl((Ast0.default_info(),Ast0.context_befaft()),$1)) }
+    { Ast0_cocci.wrap(Ast0_cocci.Decl((Ast0_cocci.default_info(),Ast0_cocci.context_befaft()),$1)) }
 | option(expr) TPtVirg { P.exp_stm $1 $2 }
 | TReturn eexpr TPtVirg { P.ret_exp $1 $2 $3 }
 | TReturn TPtVirg { P.ret $1 $2 }
@@ -1636,15 +1638,15 @@ rule_elem_statement:
 close_boolean_statement(item):
   lp = TOPar0 t = midzero_list(item,item) rp = TCPar0
     { let (mids,code) = t in
-    Ast0.wrap
-      (Ast0.Disj(P.id2mcode lp,
-		 List.map (function x -> Ast0.wrap [x]) code,
+    Ast0_cocci.wrap
+      (Ast0_cocci.Disj(P.id2mcode lp,
+		 List.map (function x -> Ast0_cocci.wrap [x]) code,
 		 mids, P.id2mcode rp)) }
 | lp = TOPar0 t = andzero_list(item,item) rp = TCPar0
     { let (mids,code) = t in
-    Ast0.wrap
-      (Ast0.Conj(P.id2mcode lp,
-		 List.map (function x -> Ast0.wrap [x]) code,
+    Ast0_cocci.wrap
+      (Ast0_cocci.Conj(P.id2mcode lp,
+		 List.map (function x -> Ast0_cocci.wrap [x]) code,
 		 mids, P.id2mcode rp)) }
 
 /* a statement on its own */
@@ -1657,20 +1659,20 @@ iso_statement: /* statement or declaration used in statement context */
   | decl_var
       { match $1 with
 	[decl] ->
-	  Ast0.wrap
-	    (Ast0.Decl((Ast0.default_info(),Ast0.context_befaft()),decl))
+	  Ast0_cocci.wrap
+	    (Ast0_cocci.Decl((Ast0_cocci.default_info(),Ast0_cocci.context_befaft()),decl))
       |	_ -> failwith "exactly one decl allowed in statement iso" }
 
 case_line:
     TDefault TDotDot fun_start
-      { Ast0.wrap
-	  (Ast0.Default(P.clt2mcode "default" $1,P.clt2mcode ":" $2,$3)) }
+      { Ast0_cocci.wrap
+	  (Ast0_cocci.Default(P.clt2mcode "default" $1,P.clt2mcode ":" $2,$3)) }
   | TCase eexpr TDotDot fun_start
-      { Ast0.wrap(Ast0.Case(P.clt2mcode "case" $1,$2,P.clt2mcode ":" $3,$4)) }
+      { Ast0_cocci.wrap(Ast0_cocci.Case(P.clt2mcode "case" $1,$2,P.clt2mcode ":" $3,$4)) }
 /*  | lp=TOPar0 t=midzero_list(case_line,case_line) rp=TCPar0
     { let (mids,code) = ([],[t]) in
-      Ast0.wrap
-	(Ast0.DisjCase(P.id2mcode lp,code,mids, P.id2mcode rp)) } */
+      Ast0_cocci.wrap
+	(Ast0_cocci.DisjCase(P.id2mcode lp,code,mids, P.id2mcode rp)) } */
 
 /* In the following, an identifier as a type is not fully supported.  Indeed,
 the language is ambiguous: what is foo * bar; */
@@ -1678,46 +1680,46 @@ the language is ambiguous: what is foo * bar; */
 a disjunction on a statement with a declaration in each branch */
 decl_var:
     t=ctype pv=TPtVirg
-      { [Ast0.wrap(Ast0.TyDecl(t,P.clt2mcode ";" pv))] }
+      { [Ast0_cocci.wrap(Ast0_cocci.TyDecl(t,P.clt2mcode ";" pv))] }
   | TMetaDecl { [P.meta_decl $1] }
   | s=ioption(storage) t=ctype
       d=comma_list(direct_declarator(disj_ident)) pv=TPtVirg
       { List.map
 	  (function (id,fn) ->
-	    Ast0.wrap(Ast0.UnInit(s,fn t,id,[],P.clt2mcode ";" pv)))
+	    Ast0_cocci.wrap(Ast0_cocci.UnInit(s,fn t,id,[],P.clt2mcode ";" pv)))
 	  d }
   | f=funproto { [f] }
   | s=ioption(storage) t=ctype d=direct_declarator(disj_ident)
     a=attr_list q=TEq e=initialize
       pv=TPtVirg
       {let (id,fn) = d in
-      [Ast0.wrap
-	  (Ast0.Init(s,fn t,id,a,P.clt2mcode "=" q,e,P.clt2mcode ";" pv))]}
+      [Ast0_cocci.wrap
+	  (Ast0_cocci.Init(s,fn t,id,a,P.clt2mcode "=" q,e,P.clt2mcode ";" pv))]}
   /* type is a typedef name */
   | s=ioption(storage) cv=ioption(const_vol) i=pure_ident_or_symbol
       d=comma_list(d_ident) pv=TPtVirg
       { List.map
 	  (function (id,fn) ->
 	    let idtype =
-	      P.make_cv cv (Ast0.wrap (Ast0.TypeName(P.id2mcode i))) in
-	    Ast0.wrap(Ast0.UnInit(s,fn idtype,id,[],P.clt2mcode ";" pv)))
+	      P.make_cv cv (Ast0_cocci.wrap (Ast0_cocci.TypeName(P.id2mcode i))) in
+	    Ast0_cocci.wrap(Ast0_cocci.UnInit(s,fn idtype,id,[],P.clt2mcode ";" pv)))
 	  d }
   | s=ioption(storage) cv=ioption(const_vol) i=pure_ident_or_symbol
       d=d_ident a=attr_list q=TEq e=initialize pv=TPtVirg
       { let (id,fn) = d in
       !Data.add_type_name (P.id2name i);
-      let idtype = P.make_cv cv (Ast0.wrap (Ast0.TypeName(P.id2mcode i))) in
-      [Ast0.wrap(Ast0.Init(s,fn idtype,id,a,P.clt2mcode "=" q,e,
+      let idtype = P.make_cv cv (Ast0_cocci.wrap (Ast0_cocci.TypeName(P.id2mcode i))) in
+      [Ast0_cocci.wrap(Ast0_cocci.Init(s,fn idtype,id,a,P.clt2mcode "=" q,e,
 			   P.clt2mcode ";" pv))] }
   | s=ioption(storage) d=decl_ident o=TOPar e=eexpr_list_option c=TCPar
       p=TPtVirg
-      { [Ast0.wrap(Ast0.MacroDecl(s,d,P.clt2mcode "(" o,e,
+      { [Ast0_cocci.wrap(Ast0_cocci.MacroDecl(s,d,P.clt2mcode "(" o,e,
 				  P.clt2mcode ")" c,P.clt2mcode ";" p))] }
   | s=ioption(storage)
       d=decl_ident o=TOPar e=eexpr_list_option c=TCPar q=TEq i=initialize
       p=TPtVirg
-      { [Ast0.wrap
-	    (Ast0.MacroDeclInit
+      { [Ast0_cocci.wrap
+	    (Ast0_cocci.MacroDeclInit
 	       (s,d,P.clt2mcode "(" o,e,
 		P.clt2mcode ")" c,P.clt2mcode "=" q,i,
 		P.clt2mcode ";" p))] }
@@ -1726,46 +1728,46 @@ decl_var:
       { let s = P.clt2mcode "typedef" s in
         List.map
 	  (function (id,fn) ->
-	    Ast0.wrap(Ast0.Typedef(s,fn t,id,P.clt2mcode ";" pv)))
+	    Ast0_cocci.wrap(Ast0_cocci.Typedef(s,fn t,id,P.clt2mcode ";" pv)))
 	  d }
 
 one_decl_var:
     t=ctype pv=TPtVirg
-      { Ast0.wrap(Ast0.TyDecl(t,P.clt2mcode ";" pv)) }
+      { Ast0_cocci.wrap(Ast0_cocci.TyDecl(t,P.clt2mcode ";" pv)) }
   | TMetaDecl { P.meta_decl $1 }
   | s=ioption(storage) t=ctype d=direct_declarator(disj_ident)
       a=attr_list pv=TPtVirg
       { let (id,fn) = d in
-        Ast0.wrap(Ast0.UnInit(s,fn t,id,a,P.clt2mcode ";" pv)) }
+        Ast0_cocci.wrap(Ast0_cocci.UnInit(s,fn t,id,a,P.clt2mcode ";" pv)) }
   | f=funproto { f }
   | s=ioption(storage) t=ctype d=direct_declarator(disj_ident)
       a=attr_list q=TEq e=initialize
       pv=TPtVirg
       { let (id,fn) = d in
-      Ast0.wrap
-	(Ast0.Init(s,fn t,id,a,P.clt2mcode "=" q,e,P.clt2mcode ";" pv)) }
+      Ast0_cocci.wrap
+	(Ast0_cocci.Init(s,fn t,id,a,P.clt2mcode "=" q,e,P.clt2mcode ";" pv)) }
   /* type is a typedef name */
   | s=ioption(storage) cv=ioption(const_vol) i=pure_ident_or_symbol
       d=d_ident a=attr_list pv=TPtVirg
       { let (id,fn) = d in
-        let idtype = P.make_cv cv (Ast0.wrap (Ast0.TypeName(P.id2mcode i))) in
-	Ast0.wrap(Ast0.UnInit(s,fn idtype,id,a,P.clt2mcode ";" pv)) }
+        let idtype = P.make_cv cv (Ast0_cocci.wrap (Ast0_cocci.TypeName(P.id2mcode i))) in
+	Ast0_cocci.wrap(Ast0_cocci.UnInit(s,fn idtype,id,a,P.clt2mcode ";" pv)) }
   | s=ioption(storage) cv=ioption(const_vol) i=pure_ident_or_symbol
       d=d_ident a=attr_list q=TEq e=initialize pv=TPtVirg
       { let (id,fn) = d in
       !Data.add_type_name (P.id2name i);
-      let idtype = P.make_cv cv (Ast0.wrap (Ast0.TypeName(P.id2mcode i))) in
-      Ast0.wrap(Ast0.Init(s,fn idtype,id,a,P.clt2mcode "=" q,e,
+      let idtype = P.make_cv cv (Ast0_cocci.wrap (Ast0_cocci.TypeName(P.id2mcode i))) in
+      Ast0_cocci.wrap(Ast0_cocci.Init(s,fn idtype,id,a,P.clt2mcode "=" q,e,
 			   P.clt2mcode ";" pv)) }
   | s=ioption(storage) d=decl_ident o=TOPar e=eexpr_list_option c=TCPar
       p=TPtVirg
-      { Ast0.wrap(Ast0.MacroDecl(s,d,P.clt2mcode "(" o,e,
+      { Ast0_cocci.wrap(Ast0_cocci.MacroDecl(s,d,P.clt2mcode "(" o,e,
 				  P.clt2mcode ")" c,P.clt2mcode ";" p)) }
   | s=ioption(storage)
       d=decl_ident o=TOPar e=eexpr_list_option c=TCPar q=TEq i=initialize
       p=TPtVirg
-      { Ast0.wrap
-            (Ast0.MacroDeclInit
+      { Ast0_cocci.wrap
+            (Ast0_cocci.MacroDeclInit
                (s,d,P.clt2mcode "(" o,e,
                 P.clt2mcode ")" c,P.clt2mcode "=" q,i,
                 P.clt2mcode ";" p)) }
@@ -1780,25 +1782,25 @@ direct_declarator(ident_type):
          function t ->
           let ty =  fn (P.pointerify t m) in
           let _ =
-           match Ast0.unwrap ty with
-            Ast0.Pointer(ty1,_) ->
-             (match Ast0.unwrap ty1 with
-               Ast0.FunctionType(ty2,_,_,_) -> ()
+           match Ast0_cocci.unwrap ty with
+            Ast0_cocci.Pointer(ty1,_) ->
+             (match Ast0_cocci.unwrap ty1 with
+               Ast0_cocci.FunctionType(ty2,_,_,_) -> ()
              | _ ->
               raise (Semantic_cocci.Semantic "expected function pointer"))
-           | Ast0.Array(ty1,_,_,_) ->
-              (match Ast0.unwrap ty1 with
-                Ast0.Pointer(ty2,_) ->(
-                 match Ast0.unwrap ty2 with
-                  Ast0.FunctionType(ty3,_,_,_) -> ()
+           | Ast0_cocci.Array(ty1,_,_,_) ->
+              (match Ast0_cocci.unwrap ty1 with
+                Ast0_cocci.Pointer(ty2,_) ->(
+                 match Ast0_cocci.unwrap ty2 with
+                  Ast0_cocci.FunctionType(ty3,_,_,_) -> ()
                  | _ ->
                   raise (Semantic_cocci.Semantic "expected function pointer"))
              | _ ->
               raise (Semantic_cocci.Semantic "expected function pointer"))
            | _ ->
             raise (Semantic_cocci.Semantic "expected function pointer") in
-          Ast0.wrap
-            (Ast0.ParenType
+          Ast0_cocci.wrap
+            (Ast0_cocci.ParenType
                (P.clt2mcode "(" o,
                 ty,
                 P.clt2mcode ")" c))) }
@@ -1810,8 +1812,8 @@ direct_declarator(ident_type):
       { let (id,fn) = d in
         (id, function t ->
               let r =
-               Ast0.wrap
-                (Ast0.FunctionType
+               Ast0_cocci.wrap
+                (Ast0_cocci.FunctionType
                   (t,P.clt2mcode "(" o,arglist,P.clt2mcode ")" c)) in fn r) }
 
 
@@ -1820,25 +1822,25 @@ direct_abstract_d:
       { function t ->
           let ty = d (P.pointerify t m) in
           let _ =
-           match Ast0.unwrap ty with
-            Ast0.Pointer(ty1,_) ->
-             (match Ast0.unwrap ty1 with
-               Ast0.FunctionType(ty2,_,_,_) ->()
+           match Ast0_cocci.unwrap ty with
+            Ast0_cocci.Pointer(ty1,_) ->
+             (match Ast0_cocci.unwrap ty1 with
+               Ast0_cocci.FunctionType(ty2,_,_,_) ->()
              | _ ->
               raise (Semantic_cocci.Semantic "expected function pointer"))
-           | Ast0.Array(ty1,_,_,_) ->
-              (match Ast0.unwrap ty1 with
-                Ast0.Pointer(ty2,_) ->(
-                 match Ast0.unwrap ty2 with
-                  Ast0.FunctionType(ty3,_,_,_) -> ()
+           | Ast0_cocci.Array(ty1,_,_,_) ->
+              (match Ast0_cocci.unwrap ty1 with
+                Ast0_cocci.Pointer(ty2,_) ->(
+                 match Ast0_cocci.unwrap ty2 with
+                  Ast0_cocci.FunctionType(ty3,_,_,_) -> ()
                  | _ ->
                   raise (Semantic_cocci.Semantic "expected function pointer"))
              | _ ->
               raise (Semantic_cocci.Semantic "expected function pointer"))
            | _ ->
             raise (Semantic_cocci.Semantic "expected function pointer") in
-          Ast0.wrap
-            (Ast0.ParenType
+          Ast0_cocci.wrap
+            (Ast0_cocci.ParenType
                (P.clt2mcode "(" o,
                 ty,
                 P.clt2mcode ")" c))
@@ -1849,14 +1851,14 @@ direct_abstract_d:
       { function t -> let r = P.arrayify t [a] in d r }
   | o=TOPar arglist=decl_list(name_opt_decl) c=TCPar
       { function t ->
-               Ast0.wrap
-                (Ast0.FunctionType
+               Ast0_cocci.wrap
+                (Ast0_cocci.FunctionType
                   (t,P.clt2mcode "(" o,arglist,P.clt2mcode ")" c)) }
   | d=direct_abstract_d o=TOPar arglist=decl_list(name_opt_decl) c=TCPar
       { function t ->
               let r =
-               Ast0.wrap
-                (Ast0.FunctionType
+               Ast0_cocci.wrap
+                (Ast0_cocci.FunctionType
                   (t,P.clt2mcode "(" o,arglist,P.clt2mcode ")" c)) in d r }
 
 
@@ -1874,57 +1876,57 @@ array_dec: l=TOCro i=option(eexpr) r=TCCro { (l,i,r) }
 
 initialize:
     eexpr
-      { Ast0.wrap(Ast0.InitExpr($1)) }
+      { Ast0_cocci.wrap(Ast0_cocci.InitExpr($1)) }
   | TOBrace initialize_list TCBrace
     { if P.struct_initializer $2
     then
       let il = P.drop_dot_commas $2 in
-      Ast0.wrap(Ast0.InitList(P.clt2mcode "{" $1,il,P.clt2mcode "}" $3,false))
+      Ast0_cocci.wrap(Ast0_cocci.InitList(P.clt2mcode "{" $1,il,P.clt2mcode "}" $3,false))
     else
-      Ast0.wrap(Ast0.InitList(P.clt2mcode "{" $1,$2,P.clt2mcode "}" $3,true)) }
+      Ast0_cocci.wrap(Ast0_cocci.InitList(P.clt2mcode "{" $1,$2,P.clt2mcode "}" $3,true)) }
   | TMetaInit
       {let (nm,cstr,pure,clt) = $1 in
-      Ast0.wrap(Ast0.MetaInit(P.clt2mcode nm clt,cstr,pure)) }
+      Ast0_cocci.wrap(Ast0_cocci.MetaInit(P.clt2mcode nm clt,cstr,pure)) }
 
 initialize2:
   /*arithexpr and not eexpr because can have ambiguity with comma*/
   /*dots and nests probably not allowed at top level, haven't looked into why*/
-  arith_expr(eexpr,invalid) { Ast0.wrap(Ast0.InitExpr($1)) }
-| nest_expressions_only     { Ast0.wrap(Ast0.InitExpr($1)) }
+  arith_expr(eexpr,invalid) { Ast0_cocci.wrap(Ast0_cocci.InitExpr($1)) }
+| nest_expressions_only     { Ast0_cocci.wrap(Ast0_cocci.InitExpr($1)) }
 | TOBrace initialize_list TCBrace
     { if P.struct_initializer $2
     then
       let il = P.drop_dot_commas $2 in
-      Ast0.wrap(Ast0.InitList(P.clt2mcode "{" $1,il,P.clt2mcode "}" $3,false))
+      Ast0_cocci.wrap(Ast0_cocci.InitList(P.clt2mcode "{" $1,il,P.clt2mcode "}" $3,false))
     else
-      Ast0.wrap(Ast0.InitList(P.clt2mcode "{" $1,$2,P.clt2mcode "}" $3,true)) }
+      Ast0_cocci.wrap(Ast0_cocci.InitList(P.clt2mcode "{" $1,$2,P.clt2mcode "}" $3,true)) }
            /* gccext:, labeled elements */
 | nonempty_list(designator) TEq initialize2
     /*can we have another of these on the rhs?*/
-    { Ast0.wrap(Ast0.InitGccExt($1,P.clt2mcode "=" $2,$3)) }
+    { Ast0_cocci.wrap(Ast0_cocci.InitGccExt($1,P.clt2mcode "=" $2,$3)) }
 | mident TDotDot initialize2
-    { Ast0.wrap(Ast0.InitGccName($1,P.clt2mcode ":" $2,$3)) } /*in old kernel*/
+    { Ast0_cocci.wrap(Ast0_cocci.InitGccName($1,P.clt2mcode ":" $2,$3)) } /*in old kernel*/
 | TMetaInit
     {let (nm,cstr,pure,clt) = $1 in
-    Ast0.wrap(Ast0.MetaInit(P.clt2mcode nm clt,cstr,pure)) }
+    Ast0_cocci.wrap(Ast0_cocci.MetaInit(P.clt2mcode nm clt,cstr,pure)) }
 | TMetaInitList
     {let (nm,lenname,cstr,pure,clt) = $1 in
     let nm = P.clt2mcode nm clt in
     let lenname = P.dolen clt lenname in
-    Ast0.wrap(Ast0.MetaInitList(nm,lenname,cstr,pure)) }
+    Ast0_cocci.wrap(Ast0_cocci.MetaInitList(nm,lenname,cstr,pure)) }
 
 designator:
  | TDot disj_ident
-     { Ast0.DesignatorField (P.clt2mcode "." $1,$2) }
+     { Ast0_cocci.DesignatorField (P.clt2mcode "." $1,$2) }
  | TOCro eexpr TCCro
-     { Ast0.DesignatorIndex (P.clt2mcode "[" $1,$2,P.clt2mcode "]" $3) }
+     { Ast0_cocci.DesignatorIndex (P.clt2mcode "[" $1,$2,P.clt2mcode "]" $3) }
  | TOCro eexpr TEllipsis eexpr TCCro
-     { Ast0.DesignatorRange (P.clt2mcode "[" $1,$2,P.clt2mcode "..." $3,
+     { Ast0_cocci.DesignatorRange (P.clt2mcode "[" $1,$2,P.clt2mcode "..." $3,
 			     $4,P.clt2mcode "]" $5) }
 
 initialize_list:
    empty_list_start(initialize2,edots_when(TEllipsis,initialize))
-     { Ast0.wrap($1 P.mkidots (fun c -> Ast0.IComma c)) }
+     { Ast0_cocci.wrap($1 P.mkidots (fun c -> Ast0_cocci.IComma c)) }
 
 /* a statement that is part of a list */
 decl_statement:
@@ -1932,8 +1934,8 @@ decl_statement:
   | decl_var
       { List.map
 	  (function x ->
-	    Ast0.wrap
-	      (Ast0.Decl((Ast0.default_info(),Ast0.context_befaft()),x)))
+	    Ast0_cocci.wrap
+	      (Ast0_cocci.Decl((Ast0_cocci.default_info(),Ast0_cocci.context_befaft()),x)))
 	  $1 }
   | statement { [$1] }
   /* this doesn't allow expressions at top level, because the parser doesn't
@@ -1947,21 +1949,21 @@ decl_statement:
       { let (mids,code) = t in
 	if List.for_all
 	    (function x ->
-	      match Ast0.unwrap x with [] -> true | _ -> false)
+	      match Ast0_cocci.unwrap x with [] -> true | _ -> false)
 	    code
       then []
       else
-	  [Ast0.wrap(Ast0.Disj(P.id2mcode $1, code, mids,
+	  [Ast0_cocci.wrap(Ast0_cocci.Disj(P.id2mcode $1, code, mids,
 			       P.id2mcode $3))] }
   | TOPar0 t=andzero_list(fun_start,fun_start) TCPar0
       { let (mids,code) = t in
 	if List.for_all
 	    (function x ->
-	      match Ast0.unwrap x with [] -> true | _ -> false)
+	      match Ast0_cocci.unwrap x with [] -> true | _ -> false)
 	    code
       then []
       else
-	  [Ast0.wrap(Ast0.Conj(P.id2mcode $1, code, mids,
+	  [Ast0_cocci.wrap(Ast0_cocci.Conj(P.id2mcode $1, code, mids,
 			       P.id2mcode $3))] }
 
 /* a statement that is part of a list */
@@ -1970,8 +1972,8 @@ decl_statement_expr:
   | decl_var
       { List.map
 	  (function x ->
-	    Ast0.wrap
-	      (Ast0.Decl((Ast0.default_info(),Ast0.context_befaft()),x)))
+	    Ast0_cocci.wrap
+	      (Ast0_cocci.Decl((Ast0_cocci.default_info(),Ast0_cocci.context_befaft()),x)))
 	  $1 }
   | statement { [$1] }
   /* this doesn't allow expressions at top level, because the parser doesn't
@@ -1986,16 +1988,16 @@ decl_statement_expr:
 	if List.for_all (function [] -> true | _ -> false) code
       then []
       else
-	  let dot_code = List.map Ast0.wrap code in
-	  [Ast0.wrap(Ast0.Disj(P.id2mcode $1, dot_code, mids,
+	  let dot_code = List.map Ast0_cocci.wrap code in
+	  [Ast0_cocci.wrap(Ast0_cocci.Disj(P.id2mcode $1, dot_code, mids,
 			       P.id2mcode $3))] }
   | TOPar0 t=andzero_list(fun_after_stm,fun_after_dots_or) TCPar0
       { let (mids,code) = t in
 	if List.for_all (function [] -> true | _ -> false) code
       then []
       else
-	  let dot_code = List.map Ast0.wrap code in
-	  [Ast0.wrap(Ast0.Conj(P.id2mcode $1, dot_code, mids,
+	  let dot_code = List.map Ast0_cocci.wrap code in
+	  [Ast0_cocci.wrap(Ast0_cocci.Conj(P.id2mcode $1, dot_code, mids,
 			       P.id2mcode $3))] }
 
 /*****************************************************************************/
@@ -2019,35 +2021,35 @@ dexpr: pre_basic_expr(eexpr,nest_expressions) { $1 }
 dargexpr: basic_expr(eexpr,nest_expressions) { $1 } /* no sequences */
 
 top_eexpr:
-  eexpr { Ast0.wrap(Ast0.OTHER(Ast0.wrap(Ast0.Exp($1)))) }
+  eexpr { Ast0_cocci.wrap(Ast0_cocci.OTHER(Ast0_cocci.wrap(Ast0_cocci.Exp($1)))) }
 
 invalid:
   TInvalid { raise (Semantic_cocci.Semantic "not matchable") }
 
 dot_expressions:
-  TEllipsis { Ast0.wrap(Ast0.Edots(P.clt2mcode "..." $1,None)) }
+  TEllipsis { Ast0_cocci.wrap(Ast0_cocci.Edots(P.clt2mcode "..." $1,None)) }
 | nest_expressions { $1 }
 
 /* not clear what whencode would mean, so just drop it */
 nest_expressions:
   TOEllipsis e=expr_dots(TEllipsis) c=TCEllipsis
-    { Ast0.wrap(Ast0.NestExpr(P.clt2mcode "<..." $1,
-			      Ast0.wrap(e (P.mkedots "...")),
+    { Ast0_cocci.wrap(Ast0_cocci.NestExpr(P.clt2mcode "<..." $1,
+			      Ast0_cocci.wrap(e (P.mkedots "...")),
 			      P.clt2mcode "...>" c, None, false)) }
 | TPOEllipsis e=expr_dots(TEllipsis) c=TPCEllipsis
-    { Ast0.wrap(Ast0.NestExpr(P.clt2mcode "<+..." $1,
-			      Ast0.wrap(e (P.mkedots "...")),
+    { Ast0_cocci.wrap(Ast0_cocci.NestExpr(P.clt2mcode "<+..." $1,
+			      Ast0_cocci.wrap(e (P.mkedots "...")),
 			      P.clt2mcode "...+>" c, None, true)) }
 | TMeta { tmeta_to_exp $1 }
 
 nest_expressions_only:
   TOEllipsis e=expr_dots(TEllipsis) c=TCEllipsis
-    { Ast0.wrap(Ast0.NestExpr(P.clt2mcode "<..." $1,
-			      Ast0.wrap(e (P.mkedots "...")),
+    { Ast0_cocci.wrap(Ast0_cocci.NestExpr(P.clt2mcode "<..." $1,
+			      Ast0_cocci.wrap(e (P.mkedots "...")),
 			      P.clt2mcode "...>" c, None, false)) }
 | TPOEllipsis e=expr_dots(TEllipsis) c=TPCEllipsis
-    { Ast0.wrap(Ast0.NestExpr(P.clt2mcode "<+..." $1,
-			      Ast0.wrap(e (P.mkedots "...")),
+    { Ast0_cocci.wrap(Ast0_cocci.NestExpr(P.clt2mcode "<+..." $1,
+			      Ast0_cocci.wrap(e (P.mkedots "...")),
 			      P.clt2mcode "...+>" c, None, true)) }
 
 //whenexp: TWhen TNotEq w=eexpr TLineEnd { w }
@@ -2056,7 +2058,7 @@ pre_basic_expr(recurser,primary_extra):
    basic_expr(recurser,primary_extra)                     { $1 }
  | pre_basic_expr(recurser,primary_extra) TComma
      basic_expr(recurser,primary_extra)
-     { Ast0.wrap(Ast0.Sequence($1,P.clt2mcode "," $2,$3)) }
+     { Ast0_cocci.wrap(Ast0_cocci.Sequence($1,P.clt2mcode "," $2,$3)) }
 
 basic_expr(recurser,primary_extra):
    assign_expr(recurser,primary_extra)                     { $1 }
@@ -2066,55 +2068,55 @@ assign_expr(r,pe):
   | unary_expr(r,pe) TOpAssign assign_expr_bis
       { let (op,clt) = $2 in
       let op' = P.clt2mcode op clt in
-      let op'' = Ast0.wrap (Ast0.OpAssign op') in
-      Ast0.wrap(Ast0.Assignment($1, op'', Ast0.set_arg_exp $3,false)) }
+      let op'' = Ast0_cocci.wrap (Ast0_cocci.OpAssign op') in
+      Ast0_cocci.wrap(Ast0_cocci.Assignment($1, op'', Ast0_cocci.set_arg_exp $3,false)) }
   | unary_expr(r,pe) TEq assign_expr_bis
       { let (op,clt) = ("=",$2) in
       let op' = P.clt2mcode op clt in
-      let op'' = Ast0.wrap (Ast0.SimpleAssign op') in
-      Ast0.wrap
-	  (Ast0.Assignment
-	     ($1, op'', Ast0.set_arg_exp $3,false)) }
+      let op'' = Ast0_cocci.wrap (Ast0_cocci.SimpleAssign op') in
+      Ast0_cocci.wrap
+	  (Ast0_cocci.Assignment
+	     ($1, op'', Ast0_cocci.set_arg_exp $3,false)) }
   | unary_expr(r,pe) TMetaAssignOp assign_expr_bis
       { let (mv, cstrt, pure, clt) = $2 in
       let op' = P.clt2mcode mv clt in
-      let op'' = Ast0.wrap (Ast0.MetaAssign (op', cstrt, pure)) in
-      Ast0.wrap
-	  (Ast0.Assignment
-	     ($1, op'', Ast0.set_arg_exp $3,false)) }
+      let op'' = Ast0_cocci.wrap (Ast0_cocci.MetaAssign (op', cstrt, pure)) in
+      Ast0_cocci.wrap
+	  (Ast0_cocci.Assignment
+	     ($1, op'', Ast0_cocci.set_arg_exp $3,false)) }
 
 assign_expr_bis:
     cond_expr(eexpr,dot_expressions)                        { $1 }
   | unary_expr(eexpr,dot_expressions) TOpAssign assign_expr_bis
       { let (op,clt) = $2 in
       let op' = P.clt2mcode op clt in
-      let op'' = Ast0.wrap (Ast0.OpAssign op') in
-      Ast0.wrap(Ast0.Assignment($1, op'', Ast0.set_arg_exp $3,false)) }
+      let op'' = Ast0_cocci.wrap (Ast0_cocci.OpAssign op') in
+      Ast0_cocci.wrap(Ast0_cocci.Assignment($1, op'', Ast0_cocci.set_arg_exp $3,false)) }
   | unary_expr(eexpr,dot_expressions) TEq assign_expr_bis
       { let (op,clt) = ("=",$2) in
       let op' = P.clt2mcode op clt in
-      let op'' = Ast0.wrap (Ast0.SimpleAssign op') in
-      Ast0.wrap
-	  (Ast0.Assignment
-	     ($1, op'', Ast0.set_arg_exp $3,false)) }
+      let op'' = Ast0_cocci.wrap (Ast0_cocci.SimpleAssign op') in
+      Ast0_cocci.wrap
+	  (Ast0_cocci.Assignment
+	     ($1, op'', Ast0_cocci.set_arg_exp $3,false)) }
 
 cond_expr(r,pe):
     arith_expr(r,pe)                         { $1 }
   | l=arith_expr(r,pe) w=TWhy t=option(eexpr)
       dd=TDotDot r=eargexpr/*see parser_c*/
-      { Ast0.wrap(Ast0.CondExpr (l, P.clt2mcode "?" w, t,
+      { Ast0_cocci.wrap(Ast0_cocci.CondExpr (l, P.clt2mcode "?" w, t,
 				 P.clt2mcode ":" dd, r)) }
 
 arith_expr(r,pe):
     cast_expr(r,pe)                         { $1 }
   | arith_expr(r,pe) TMul    arith_expr_bis
-    { P.arith_op Ast.Mul $1 $2 $3 }
+    { P.arith_op Ast_cocci.Mul $1 $2 $3 }
   | arith_expr(r,pe) TDmOp    arith_expr_bis
       { let (op,clt) = $2 in P.arith_op op $1 clt $3 }
   | arith_expr(r,pe) TPlus   arith_expr_bis
-      { P.arith_op Ast.Plus $1 $2 $3 }
+      { P.arith_op Ast_cocci.Plus $1 $2 $3 }
   | arith_expr(r,pe) TMinus  arith_expr_bis
-      { P.arith_op Ast.Minus $1 $2 $3 }
+      { P.arith_op Ast_cocci.Minus $1 $2 $3 }
   | arith_expr(r,pe) TShLOp    arith_expr_bis
       { let (op,clt) = $2 in P.arith_op op $1 clt $3 }
   | arith_expr(r,pe) TShROp    arith_expr_bis
@@ -2122,37 +2124,37 @@ arith_expr(r,pe):
   | arith_expr(r,pe) TLogOp    arith_expr_bis
       { let (op,clt) = $2 in P.logic_op op $1 clt $3 }
   | arith_expr(r,pe) TEqEq   arith_expr_bis
-      { P.logic_op Ast.Eq $1 $2 $3 }
+      { P.logic_op Ast_cocci.Eq $1 $2 $3 }
   | arith_expr(r,pe) TNotEq  arith_expr_bis
-      { P.logic_op Ast.NotEq $1 $2 $3 }
+      { P.logic_op Ast_cocci.NotEq $1 $2 $3 }
   | arith_expr(r,pe) TAnd    arith_expr_bis
-      { P.arith_op Ast.And $1 $2 $3 }
+      { P.arith_op Ast_cocci.And $1 $2 $3 }
   | arith_expr(r,pe) TOr     arith_expr_bis
-      { P.arith_op Ast.Or $1 $2 $3 }
+      { P.arith_op Ast_cocci.Or $1 $2 $3 }
   | arith_expr(r,pe) TXor    arith_expr_bis
-      { P.arith_op Ast.Xor $1 $2 $3 }
+      { P.arith_op Ast_cocci.Xor $1 $2 $3 }
   | arith_expr(r,pe) TAndLog arith_expr_bis
-      { P.logic_op Ast.AndLog $1 $2 $3 }
+      { P.logic_op Ast_cocci.AndLog $1 $2 $3 }
   | arith_expr(r,pe) TOrLog  arith_expr_bis
-      { P.logic_op Ast.OrLog $1 $2 $3 }
+      { P.logic_op Ast_cocci.OrLog $1 $2 $3 }
   | arith_expr(r,pe) TMetaBinaryOp  arith_expr_bis
       { let (mv, cstrt, pure, clt) = $2 in
       let op' = P.clt2mcode mv clt in
-      let op = Ast0.wrap (Ast0.MetaBinary (op', cstrt, pure)) in
-      Ast0.wrap (Ast0.Binary($1, op, $3)) }
+      let op = Ast0_cocci.wrap (Ast0_cocci.MetaBinary (op', cstrt, pure)) in
+      Ast0_cocci.wrap (Ast0_cocci.Binary($1, op, $3)) }
 
 // allows dots now that an expression-specific token has been seen
 // need an extra rule because of recursion restrictions
 arith_expr_bis:
     cast_expr(eexpr,dot_expressions)                         { $1 }
   | arith_expr_bis TMul    arith_expr_bis
-      { P.arith_op Ast.Mul $1 $2 $3 }
+      { P.arith_op Ast_cocci.Mul $1 $2 $3 }
   | arith_expr_bis TDmOp    arith_expr_bis
       { let (op,clt) = $2 in P.arith_op op $1 clt $3 }
   | arith_expr_bis TPlus   arith_expr_bis
-      { P.arith_op Ast.Plus $1 $2 $3 }
+      { P.arith_op Ast_cocci.Plus $1 $2 $3 }
   | arith_expr_bis TMinus  arith_expr_bis
-      { P.arith_op Ast.Minus $1 $2 $3 }
+      { P.arith_op Ast_cocci.Minus $1 $2 $3 }
   | arith_expr_bis TShLOp    arith_expr_bis
       { let (op,clt) = $2 in P.arith_op op $1 clt $3 }
   | arith_expr_bis TShROp    arith_expr_bis
@@ -2160,41 +2162,41 @@ arith_expr_bis:
   | arith_expr_bis TLogOp    arith_expr_bis
       { let (op,clt) = $2 in P.logic_op op $1 clt $3 }
   | arith_expr_bis TEqEq   arith_expr_bis
-      { P.logic_op Ast.Eq $1 $2 $3 }
+      { P.logic_op Ast_cocci.Eq $1 $2 $3 }
   | arith_expr_bis TNotEq  arith_expr_bis
-      { P.logic_op Ast.NotEq $1 $2 $3 }
+      { P.logic_op Ast_cocci.NotEq $1 $2 $3 }
   | arith_expr_bis TAnd    arith_expr_bis
-      { P.arith_op Ast.And $1 $2 $3 }
+      { P.arith_op Ast_cocci.And $1 $2 $3 }
   | arith_expr_bis TOr     arith_expr_bis
-      { P.arith_op Ast.Or $1 $2 $3 }
+      { P.arith_op Ast_cocci.Or $1 $2 $3 }
   | arith_expr_bis TXor    arith_expr_bis
-      { P.arith_op Ast.Xor $1 $2 $3 }
+      { P.arith_op Ast_cocci.Xor $1 $2 $3 }
   | arith_expr_bis TAndLog arith_expr_bis
-      { P.logic_op Ast.AndLog $1 $2 $3 }
+      { P.logic_op Ast_cocci.AndLog $1 $2 $3 }
 // no OrLog because it is left associative and this is for
 // a right argument, not sure why not the same problem for AndLog
 
 cast_expr(r,pe):
     unary_expr(r,pe)                      { $1 }
   | lp=TOPar t=ctype rp=TCPar e=cast_expr(r,pe)
-      { Ast0.wrap(Ast0.Cast (P.clt2mcode "(" lp, t,
+      { Ast0_cocci.wrap(Ast0_cocci.Cast (P.clt2mcode "(" lp, t,
                              P.clt2mcode ")" rp, e)) }
   | lp=TOPar t=ctype d=direct_abstract_d rp=TCPar e=cast_expr(r,pe)
-      { Ast0.wrap(Ast0.Cast (P.clt2mcode "(" lp, d t,
+      { Ast0_cocci.wrap(Ast0_cocci.Cast (P.clt2mcode "(" lp, d t,
 			     P.clt2mcode ")" rp, e)) }
 
 unary_expr(r,pe):
     postfix_expr(r,pe)                   { $1 }
   | TInc unary_expr_bis
-      { Ast0.wrap(Ast0.Infix ($2, P.clt2mcode Ast.Inc $1)) }
+      { Ast0_cocci.wrap(Ast0_cocci.Infix ($2, P.clt2mcode Ast_cocci.Inc $1)) }
   | TDec unary_expr_bis
-      { Ast0.wrap(Ast0.Infix ($2, P.clt2mcode Ast.Dec $1)) }
+      { Ast0_cocci.wrap(Ast0_cocci.Infix ($2, P.clt2mcode Ast_cocci.Dec $1)) }
   | unary_op cast_expr(r,pe)
-      { let mcode = $1 in Ast0.wrap(Ast0.Unary($2, mcode)) }
+      { let mcode = $1 in Ast0_cocci.wrap(Ast0_cocci.Unary($2, mcode)) }
   | TSizeof unary_expr_bis
-      { Ast0.wrap(Ast0.SizeOfExpr (P.clt2mcode "sizeof" $1, $2)) }
+      { Ast0_cocci.wrap(Ast0_cocci.SizeOfExpr (P.clt2mcode "sizeof" $1, $2)) }
   | s=TSizeof lp=TOPar t=ctype rp=TCPar
-      { Ast0.wrap(Ast0.SizeOfType (P.clt2mcode "sizeof" s,
+      { Ast0_cocci.wrap(Ast0_cocci.SizeOfType (P.clt2mcode "sizeof" s,
                                    P.clt2mcode "(" lp,t,
                                    P.clt2mcode ")" rp)) }
 
@@ -2202,41 +2204,41 @@ unary_expr(r,pe):
 unary_expr_bis:
     postfix_expr(eexpr,dot_expressions)                   { $1 }
   | TInc unary_expr_bis
-      { Ast0.wrap(Ast0.Infix ($2, P.clt2mcode Ast.Inc $1)) }
+      { Ast0_cocci.wrap(Ast0_cocci.Infix ($2, P.clt2mcode Ast_cocci.Inc $1)) }
   | TDec unary_expr_bis
-      { Ast0.wrap(Ast0.Infix ($2, P.clt2mcode Ast.Dec $1)) }
+      { Ast0_cocci.wrap(Ast0_cocci.Infix ($2, P.clt2mcode Ast_cocci.Dec $1)) }
   | unary_op cast_expr(eexpr,dot_expressions)
-      { let mcode = $1 in Ast0.wrap(Ast0.Unary($2, mcode)) }
+      { let mcode = $1 in Ast0_cocci.wrap(Ast0_cocci.Unary($2, mcode)) }
   | TSizeof unary_expr_bis
-      { Ast0.wrap(Ast0.SizeOfExpr (P.clt2mcode "sizeof" $1, $2)) }
+      { Ast0_cocci.wrap(Ast0_cocci.SizeOfExpr (P.clt2mcode "sizeof" $1, $2)) }
   | s=TSizeof lp=TOPar t=ctype rp=TCPar
-      { Ast0.wrap(Ast0.SizeOfType (P.clt2mcode "sizeof" s,
+      { Ast0_cocci.wrap(Ast0_cocci.SizeOfType (P.clt2mcode "sizeof" s,
                                    P.clt2mcode "(" lp,t,
                                    P.clt2mcode ")" rp)) }
 
-unary_op: TAnd    { P.clt2mcode Ast.GetRef $1 }
-	| TMul    { P.clt2mcode Ast.DeRef $1 }
-	| TPlus   { P.clt2mcode Ast.UnPlus $1 }
-	| TMinus  { P.clt2mcode Ast.UnMinus $1 }
-	| TTilde  { P.clt2mcode Ast.Tilde $1 }
-	| TBang   { P.clt2mcode Ast.Not $1 }
+unary_op: TAnd    { P.clt2mcode Ast_cocci.GetRef $1 }
+	| TMul    { P.clt2mcode Ast_cocci.DeRef $1 }
+	| TPlus   { P.clt2mcode Ast_cocci.UnPlus $1 }
+	| TMinus  { P.clt2mcode Ast_cocci.UnMinus $1 }
+	| TTilde  { P.clt2mcode Ast_cocci.Tilde $1 }
+	| TBang   { P.clt2mcode Ast_cocci.Not $1 }
 
 postfix_expr(r,pe):
    primary_expr(r,pe)                            { $1 }
  | postfix_expr(r,pe) TOCro eexpr TCCro
-     { Ast0.wrap(Ast0.ArrayAccess ($1,P.clt2mcode "[" $2,$3,
+     { Ast0_cocci.wrap(Ast0_cocci.ArrayAccess ($1,P.clt2mcode "[" $2,$3,
 				       P.clt2mcode "]" $4)) }
  | postfix_expr(r,pe) TDot   disj_ident
-     { Ast0.wrap(Ast0.RecordAccess($1, P.clt2mcode "." $2, $3)) }
+     { Ast0_cocci.wrap(Ast0_cocci.RecordAccess($1, P.clt2mcode "." $2, $3)) }
  | postfix_expr(r,pe) TPtrOp disj_ident
-     { Ast0.wrap(Ast0.RecordPtAccess($1, P.clt2mcode "->" $2,
+     { Ast0_cocci.wrap(Ast0_cocci.RecordPtAccess($1, P.clt2mcode "->" $2,
 				     $3)) }
  | postfix_expr(r,pe) TInc
-     { Ast0.wrap(Ast0.Postfix ($1, P.clt2mcode Ast.Inc $2)) }
+     { Ast0_cocci.wrap(Ast0_cocci.Postfix ($1, P.clt2mcode Ast_cocci.Inc $2)) }
  | postfix_expr(r,pe) TDec
-     { Ast0.wrap(Ast0.Postfix ($1, P.clt2mcode Ast.Dec $2)) }
+     { Ast0_cocci.wrap(Ast0_cocci.Postfix ($1, P.clt2mcode Ast_cocci.Dec $2)) }
  | postfix_expr(r,pe) TOPar eexpr_list_option TCPar
-     { Ast0.wrap(Ast0.FunCall($1,P.clt2mcode "(" $2,
+     { Ast0_cocci.wrap(Ast0_cocci.FunCall($1,P.clt2mcode "(" $2,
 			      $3,
 			      P.clt2mcode ")" $4)) }
  /*(* gccext: also called compound literals *)
@@ -2246,71 +2248,71 @@ postfix_expr(r,pe):
        if P.struct_initializer $5
        then
 	 let il = P.drop_dot_commas $5 in
-	 Ast0.wrap
-	   (Ast0.InitList(P.clt2mcode "{" $4,il,P.clt2mcode "}" $6,false))
+	 Ast0_cocci.wrap
+	   (Ast0_cocci.InitList(P.clt2mcode "{" $4,il,P.clt2mcode "}" $6,false))
        else
-	 Ast0.wrap
-	   (Ast0.InitList(P.clt2mcode "{" $4,$5,P.clt2mcode "}" $6,true)) in
-     Ast0.wrap
-       (Ast0.Constructor(P.clt2mcode "(" $1, $2, P.clt2mcode ")" $3, init)) }
+	 Ast0_cocci.wrap
+	   (Ast0_cocci.InitList(P.clt2mcode "{" $4,$5,P.clt2mcode "}" $6,true)) in
+     Ast0_cocci.wrap
+       (Ast0_cocci.Constructor(P.clt2mcode "(" $1, $2, P.clt2mcode ")" $3, init)) }
 
 primary_expr(recurser,primary_extra):
-   func_ident   { Ast0.wrap(Ast0.Ident($1)) }
+   func_ident   { Ast0_cocci.wrap(Ast0_cocci.Ident($1)) }
  | TAndLog ident
-     { let op = P.clt2mcode Ast.GetRefLabel $1 in
-     Ast0.wrap(Ast0.Unary(Ast0.wrap(Ast0.Ident($2)), op)) }
+     { let op = P.clt2mcode Ast_cocci.GetRefLabel $1 in
+     Ast0_cocci.wrap(Ast0_cocci.Unary(Ast0_cocci.wrap(Ast0_cocci.Ident($2)), op)) }
  | TInt
      { let (x,clt) = $1 in
-     Ast0.wrap(Ast0.Constant (P.clt2mcode (Ast.Int x) clt)) }
+     Ast0_cocci.wrap(Ast0_cocci.Constant (P.clt2mcode (Ast_cocci.Int x) clt)) }
  | TFloat
      { let (x,clt) = $1 in
-     Ast0.wrap(Ast0.Constant (P.clt2mcode (Ast.Float x) clt)) }
+     Ast0_cocci.wrap(Ast0_cocci.Constant (P.clt2mcode (Ast_cocci.Float x) clt)) }
  | TString
      { let (x,sz,clt) = $1 in P.parse_string x clt sz }
  | TChar
      { let (x,sz,clt) = $1 in
-     Ast0.wrap(Ast0.Constant (P.clt2mcode (Ast.Char(x,sz)) clt)) }
+     Ast0_cocci.wrap(Ast0_cocci.Constant (P.clt2mcode (Ast_cocci.Char(x,sz)) clt)) }
  | TDecimalCst
      { let (x,l,p,clt) = $1 in
-     Ast0.wrap(Ast0.Constant (P.clt2mcode (Ast.DecimalConst(x,l,p)) clt)) }
+     Ast0_cocci.wrap(Ast0_cocci.Constant (P.clt2mcode (Ast_cocci.DecimalConst(x,l,p)) clt)) }
  | TMetaConst
      { let (nm,constraints,pure,ty,clt) = $1 in
-     Ast0.wrap
-       (Ast0.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast.CONST,pure,None)) }
+     Ast0_cocci.wrap
+       (Ast0_cocci.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast_cocci.CONST,pure,None)) }
  | TMetaErr
      { let (nm,constraints,pure,clt) = $1 in
-     Ast0.wrap(Ast0.MetaErr(P.clt2mcode nm clt,constraints,pure)) }
+     Ast0_cocci.wrap(Ast0_cocci.MetaErr(P.clt2mcode nm clt,constraints,pure)) }
  | TMetaExp
      { let (nm,constraints,pure,ty,clt,bitfield) = $1 in
      let bitfield' = Common.map_option (P.dolen clt) bitfield in
-     Ast0.wrap
-       (Ast0.MetaExpr
-	  (P.clt2mcode nm clt,constraints,ty,Ast.ANY,pure,bitfield')) }
+     Ast0_cocci.wrap
+       (Ast0_cocci.MetaExpr
+	  (P.clt2mcode nm clt,constraints,ty,Ast_cocci.ANY,pure,bitfield')) }
  | TMetaIdExp
      { let (nm,constraints,pure,ty,clt) = $1 in
-     Ast0.wrap
-       (Ast0.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast.ID,pure,None)) }
+     Ast0_cocci.wrap
+       (Ast0_cocci.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast_cocci.ID,pure,None)) }
  | TMetaLocalIdExp
      { let (nm,constraints,pure,ty,clt) = $1 in
-     Ast0.wrap
-       (Ast0.MetaExpr
-	  (P.clt2mcode nm clt,constraints,ty,Ast.LocalID,pure,None)) }
+     Ast0_cocci.wrap
+       (Ast0_cocci.MetaExpr
+	  (P.clt2mcode nm clt,constraints,ty,Ast_cocci.LocalID,pure,None)) }
  | TMetaGlobalIdExp
      { let (nm,constraints,pure,ty,clt) = $1 in
-     Ast0.wrap
-       (Ast0.MetaExpr
-	  (P.clt2mcode nm clt,constraints,ty,Ast.GlobalID,pure,None)) }
+     Ast0_cocci.wrap
+       (Ast0_cocci.MetaExpr
+	  (P.clt2mcode nm clt,constraints,ty,Ast_cocci.GlobalID,pure,None)) }
  | TOPar eexpr TCPar
-     { Ast0.wrap(Ast0.Paren(P.clt2mcode "(" $1,$2,
+     { Ast0_cocci.wrap(Ast0_cocci.Paren(P.clt2mcode "(" $1,$2,
 			    P.clt2mcode ")" $3)) }
  | TOPar0 midzero_list(recurser,eexpr) TCPar0
      { let (mids,code) = $2 in
-       Ast0.wrap(Ast0.DisjExpr(P.id2mcode $1,
+       Ast0_cocci.wrap(Ast0_cocci.DisjExpr(P.id2mcode $1,
 			       code, mids,
 			       P.id2mcode $3)) }
  | TOPar0 andzero_list(recurser,eexpr) TCPar0
      { let (mids,code) = $2 in
-       Ast0.wrap(Ast0.ConjExpr(P.id2mcode $1,
+       Ast0_cocci.wrap(Ast0_cocci.ConjExpr(P.id2mcode $1,
 			       code, mids,
 			       P.id2mcode $3)) }
  | primary_extra { $1 }
@@ -2419,14 +2421,14 @@ inherited_or_local_meta:
      | TRuleName TDot pure_ident_kwd { ($1,$3) }
 
 wrapped_sym_ident:
-  TSymId { Ast0.wrap(Ast0.Id(P.sym2mcode $1)) }
+  TSymId { Ast0_cocci.wrap(Ast0_cocci.Id(P.sym2mcode $1)) }
 
 pure_ident_or_meta_ident_with_seed:
-      | pure_ident_or_meta_ident { ($1,Ast.NoVal) }
+      | pure_ident_or_meta_ident { ($1,Ast_cocci.NoVal) }
       | pure_ident_or_meta_ident TEq separated_nonempty_list(TCppConcatOp,seed_elem)
         { match $3 with
-          | [Ast.SeedString s] -> ($1,Ast.StringSeed s)
-          | _ -> ($1,Ast.ListSeed $3) }
+          | [Ast_cocci.SeedString s] -> ($1,Ast_cocci.StringSeed s)
+          | _ -> ($1,Ast_cocci.ListSeed $3) }
       | nm=pure_ident_or_meta_ident TEq pos=TScript TDotDot lang=pure_ident
           TOPar params=loption(comma_list(inherited_or_local_meta)) TCPar
           TOBrace c=list(anything) TCBrace
@@ -2438,23 +2440,23 @@ pure_ident_or_meta_ident_with_seed:
             | Some r, n -> r, n in
           Data.fresh_id_scripts :=
             (nm', script) :: !Data.fresh_id_scripts;
-          (nm, Ast.ScriptSeed script) }
+          (nm, Ast_cocci.ScriptSeed script) }
 
 seed_elem:
-  TString { let (x,_,_) = $1 in Ast.SeedString x }
-| TMetaId { let (x,_,_,_,_) = $1 in Ast.SeedId x }
+  TString { let (x,_,_) = $1 in Ast_cocci.SeedString x }
+| TMetaId { let (x,_,_,_,_) = $1 in Ast_cocci.SeedId x }
 | TMeta {failwith "tmeta"}
 | TVirtual TDot pure_ident
     { let nm = ("virtual",P.id2name $3) in
      Iteration.parsed_virtual_identifiers :=
        Common.union_set [snd nm]
 	 !Iteration.parsed_virtual_identifiers;
-    try Ast.SeedString (List.assoc (snd nm) !Flag.defined_virtual_env)
-    with Not_found -> Ast.SeedId nm }
+    try Ast_cocci.SeedString (List.assoc (snd nm) !Flag.defined_virtual_env)
+    with Not_found -> Ast_cocci.SeedId nm }
 | TRuleName TDot pure_ident
     { let nm = ($1,P.id2name $3) in
-      P.check_meta(Ast.MetaIdDecl(Ast.NONE,nm));
-      Ast.SeedId nm }
+      P.check_meta(Ast_cocci.MetaIdDecl(Ast_cocci.NONE,nm));
+      Ast_cocci.SeedId nm }
 
 pure_ident_or_meta_ident_with_constraints:
   i=pure_ident_or_meta_ident c=constraints { (i,c Data.OTHR i) }
@@ -2475,7 +2477,7 @@ pure_ident_or_meta_ident_with_constraints_virt:
       Common.Right nm }
 
 constraints:
-    { fun _ _ -> Ast.CstrTrue }
+    { fun _ _ -> Ast_cocci.CstrTrue }
 | c=nonempty_constraints
     { check_constraint_allowed ();
       c }
@@ -2484,24 +2486,24 @@ constraints:
 make sense for positions and comments *)
 nonempty_constraints:
   TTildeEq re=TString
-    { fun _ _ -> let (s,_,_) = re in Ast.CstrRegexp (s,Regexp.regexp s) }
+    { fun _ _ -> let (s,_,_) = re in Ast_cocci.CstrRegexp (s,Regexp.regexp s) }
 | TTildeExclEq re=TString
     { fun _ _ ->
-      let (s,_,_) = re in Ast.CstrNot (Ast.CstrRegexp (s,Regexp.regexp s)) }
-| TEq l=item_or_brace_list(cstr_ident) { fun _ _ -> Ast.CstrOr l }
+      let (s,_,_) = re in Ast_cocci.CstrNot (Ast_cocci.CstrRegexp (s,Regexp.regexp s)) }
+| TEq l=item_or_brace_list(cstr_ident) { fun _ _ -> Ast_cocci.CstrOr l }
 | TNotEq l=item_or_brace_list(cstr_ident)
-    { fun _ _ -> Ast.CstrNot (Ast.CstrOr l) }
+    { fun _ _ -> Ast_cocci.CstrNot (Ast_cocci.CstrOr l) }
 | TSub i=TInt { fun _ _ ->
   let i = int_of_string (fst i) in
-  Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntLeq i)) }
+  Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntLeq i)) }
 | o=TLogOp i=TInt { fun _ _ ->
   let i = int_of_string (fst i) in
   match o with
-    Ast.SupEq, _ -> Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntGeq i))
-  | Ast.Inf, _ -> Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntLeq (pred i)))
-  | Ast.Sup, _ -> Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntGeq (succ i)))
+    Ast_cocci.SupEq, _ -> Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntGeq i))
+  | Ast_cocci.Inf, _ -> Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntLeq (pred i)))
+  | Ast_cocci.Sup, _ -> Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntGeq (succ i)))
   | _ -> raise (Semantic_cocci.Semantic "unknown constraint operator") }
-| TSub l=item_or_brace_list(sub_meta_ident) { fun _ _ -> Ast.CstrSub l }
+| TSub l=item_or_brace_list(sub_meta_ident) { fun _ _ -> Ast_cocci.CstrSub l }
 | TDotDot pos=TScript TDotDot lang=pure_ident
     TOPar params=loption(comma_list(inherited_or_local_meta)) TCPar
     TOBrace c=list(anything) TCBrace
@@ -2512,23 +2514,23 @@ nonempty_constraints:
           None, n -> "", n
         | Some r, n -> r, n in
       let local =
-	List.for_all (fun (rl,_) -> not (rl = !Ast0.rule_name)) params in
+	List.for_all (fun (rl,_) -> not (rl = !Ast0_cocci.rule_name)) params in
       Data.constraint_scripts :=
         (posvar, nm', script) :: !Data.constraint_scripts;
       (if not local
       then
 	(let mv =
 	  match nm with
-	    (None,nm) -> (!Ast0.rule_name,nm)
+	    (None,nm) -> (!Ast0_cocci.rule_name,nm)
 	  | (Some rule,nm) -> (rule,nm) in
 	Common.hashadd Data.non_local_script_constraints
-	  (!Ast0.rule_name,mv) (mv,script)));
-      Ast.CstrScript (local,script) }
-| TBang c = nonempty_constraints { fun posvar nm -> Ast.CstrNot (c posvar nm) }
+	  (!Ast0_cocci.rule_name,mv) (mv,script)));
+      Ast_cocci.CstrScript (local,script) }
+| TBang c = nonempty_constraints { fun posvar nm -> Ast_cocci.CstrNot (c posvar nm) }
 | l=nonempty_constraints TAndLog r=nonempty_constraints
-    { fun posvar nm -> Ast.CstrAnd [l posvar nm; r posvar nm] }
+    { fun posvar nm -> Ast_cocci.CstrAnd [l posvar nm; r posvar nm] }
 | l=nonempty_constraints TOrLog r=nonempty_constraints
-    { fun posvar nm -> Ast.CstrOr [l posvar nm; r posvar nm] }
+    { fun posvar nm -> Ast_cocci.CstrOr [l posvar nm; r posvar nm] }
 | TOPar c=nonempty_constraints TCPar { c }
 
 item_or_brace_list(item):
@@ -2538,38 +2540,38 @@ item_or_brace_list(item):
 cstr_ident:
   c=ctype_or_ident
   { match c with
-      Common.Left ty -> Ast.CstrType (Ast0toast.typeC false ty)
+      Common.Left ty -> Ast_cocci.CstrType (Ast0toast.typeC false ty)
     | Common.Right i ->
 	match i with
 	  (Some rn,id) ->
 	    let i = P.check_inherited_constraint_without_type i in
-	    (Ast.CstrMeta_name i)
-	| (None,s) -> Ast.CstrConstant (Ast.CstrString s) }
+	    (Ast_cocci.CstrMeta_name i)
+	| (None,s) -> Ast_cocci.CstrConstant (Ast_cocci.CstrString s) }
 | i=TInt {
   let i = fst i in
-  Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntEq i)) }
+  Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntEq i)) }
 | i=TInt TDot TDot TDot j=TInt {
   let i = int_of_string (fst i) and j = int_of_string (fst j) in
-  Ast.CstrAnd [
-  Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntGeq i));
-  Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntLeq j))] }
+  Ast_cocci.CstrAnd [
+  Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntGeq i));
+  Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntLeq j))] }
 | i=TFloat TDot TDot j=TInt { (* compensate for bad lexing *)
   let i = int_of_string (P.unfloatl(fst i)) and j = int_of_string (fst j) in
-  Ast.CstrAnd [
-  Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntGeq i));
-  Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntLeq j))] }
+  Ast_cocci.CstrAnd [
+  Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntGeq i));
+  Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntLeq j))] }
 | i=TInt TDot TDot j=TFloat {
   let i = int_of_string (fst i) and j = int_of_string (P.unfloatr(fst j)) in
-  Ast.CstrAnd [
-  Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntGeq i));
-  Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntLeq j))] }
+  Ast_cocci.CstrAnd [
+  Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntGeq i));
+  Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntLeq j))] }
 | i=TFloat TDot j=TFloat {
   let i = int_of_string (P.unfloatl(fst i))
   and j = int_of_string (P.unfloatr(fst j)) in
-  Ast.CstrAnd [
-  Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntGeq i));
-  Ast.CstrConstant (Ast.CstrInt (Ast.CstrIntLeq j))] }
-| op=operator_constraint { Ast.CstrOperator op }
+  Ast_cocci.CstrAnd [
+  Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntGeq i));
+  Ast_cocci.CstrConstant (Ast_cocci.CstrInt (Ast_cocci.CstrIntLeq j))] }
+| op=operator_constraint { Ast_cocci.CstrOperator op }
 
 ctype_or_ident:
 | cv=ioption(const_vol) c=all_basic_types_or_ident m=list(mul)
@@ -2580,13 +2582,13 @@ ctype_or_ident:
 	    match c with
 	      Common.Left ty -> ty
 	    | Common.Right (None, p) ->
-		Ast0.wrap(Ast0.TypeName(Ast0.make_mcode p))
+		Ast0_cocci.wrap(Ast0_cocci.TypeName(Ast0_cocci.make_mcode p))
 	    | Common.Right (Some r, p) ->
 		let nm = (r, p) in
-		let _ = P.check_meta(Ast.MetaTypeDecl(Ast.NONE,nm)) in
-		Ast0.wrap(
-		  Ast0.MetaType(Ast0.make_mcode nm,Ast.CstrTrue,
-				Ast0.Impure (*will be ignored*))) in
+		let _ = P.check_meta(Ast_cocci.MetaTypeDecl(Ast_cocci.NONE,nm)) in
+		Ast0_cocci.wrap(
+		  Ast0_cocci.MetaType(Ast0_cocci.make_mcode nm,Ast_cocci.CstrTrue,
+				Ast0_cocci.Impure (*will be ignored*))) in
 	  let f prev (star,cv) = P.make_cv cv (P.pointerify prev [star]) in
 	  Common.Left (List.fold_left f (P.make_cv cv ty) m) }
 | ty=signed_or_unsigned { Common.Left ty }
@@ -2596,35 +2598,35 @@ all_basic_types_or_ident:
 | i=pure_ident_or_meta_ident_nosym2(TSymId) { Common.Right i }
 
 operator_constraint:
-  op=binary_operator { Ast.CstrBinaryOp (Ast0toast.binaryOp op) }
-| op=assignment_operator { Ast.CstrAssignOp (Ast0toast.assignOp op) }
+  op=binary_operator { Ast_cocci.CstrBinaryOp (Ast0toast.binaryOp op) }
+| op=assignment_operator { Ast_cocci.CstrAssignOp (Ast0toast.assignOp op) }
 
 binary_operator:
-  TShLOp { mkarithop $1 } (* Ast.Arith Ast.DecLeft *)
-| TMul { mkarithop (Ast.Mul,$1) }
-| TEqEq { mklogop (Ast.Eq,$1) }
-| TNotEq { mklogop (Ast.NotEq,$1) }
-| TSub { mklogop (Ast.InfEq,$1) }
-| TPlus { mkarithop (Ast.Plus,$1) }
-| TMinus { mkarithop (Ast.Minus,$1) }
+  TShLOp { mkarithop $1 } (* Ast_cocci.Arith Ast_cocci.DecLeft *)
+| TMul { mkarithop (Ast_cocci.Mul,$1) }
+| TEqEq { mklogop (Ast_cocci.Eq,$1) }
+| TNotEq { mklogop (Ast_cocci.NotEq,$1) }
+| TSub { mklogop (Ast_cocci.InfEq,$1) }
+| TPlus { mkarithop (Ast_cocci.Plus,$1) }
+| TMinus { mkarithop (Ast_cocci.Minus,$1) }
 | TDmOp { mkarithop $1 }
 | TShROp { mkarithop $1 }
-| TAnd { mkarithop (Ast.And,$1) }
-| TOr { mkarithop (Ast.Or,$1) }
-| TXor { mkarithop (Ast.Xor,$1) }
+| TAnd { mkarithop (Ast_cocci.And,$1) }
+| TOr { mkarithop (Ast_cocci.Or,$1) }
+| TXor { mkarithop (Ast_cocci.Xor,$1) }
 | TLogOp { mklogop $1 }
-| TAndLog { mklogop (Ast.AndLog,$1) }
-| TOrLog { mklogop (Ast.OrLog,$1) }
+| TAndLog { mklogop (Ast_cocci.AndLog,$1) }
+| TOrLog { mklogop (Ast_cocci.OrLog,$1) }
 
 assignment_operator:
   TEq
     { let clt = $1 in
       let op' = P.clt2mcode "=" clt in
-      Ast0.wrap (Ast0.SimpleAssign op') }
+      Ast0_cocci.wrap (Ast0_cocci.SimpleAssign op') }
 | TOpAssign
     { let (op,clt) = $1 in
       let op' = P.clt2mcode op clt in
-      Ast0.wrap (Ast0.OpAssign op') }
+      Ast0_cocci.wrap (Ast0_cocci.OpAssign op') }
 
 sub_meta_ident:
      (* has to be inherited because not clear how to check subterm constraints
@@ -2632,41 +2634,41 @@ sub_meta_ident:
 	already when bind the subterm constrained metavariable *)
   i=meta_ident
     { P.check_inherited_constraint i
-	(function mv -> Ast.MetaExpDecl(Ast.NONE,mv,None,None)) }
+	(function mv -> Ast_cocci.MetaExpDecl(Ast_cocci.NONE,mv,None,None)) }
 
 func_ident:
        ident { $1 }
      | TMetaFunc
          { let (nm,constraints,pure,clt) = $1 in
-	 Ast0.wrap(Ast0.MetaFunc(P.clt2mcode nm clt,constraints,pure)) }
+	 Ast0_cocci.wrap(Ast0_cocci.MetaFunc(P.clt2mcode nm clt,constraints,pure)) }
      | TMetaLocalFunc
 	 { let (nm,constraints,pure,clt) = $1 in
-	 Ast0.wrap
-	   (Ast0.MetaLocalFunc(P.clt2mcode nm clt,constraints,pure)) }
+	 Ast0_cocci.wrap
+	   (Ast0_cocci.MetaLocalFunc(P.clt2mcode nm clt,constraints,pure)) }
 
 fn_ident: disj_ident { $1 }
      | TMetaFunc
          { let (nm,constraints,pure,clt) = $1 in
-	 Ast0.wrap(Ast0.MetaFunc(P.clt2mcode nm clt,constraints,pure)) }
+	 Ast0_cocci.wrap(Ast0_cocci.MetaFunc(P.clt2mcode nm clt,constraints,pure)) }
      | TMetaLocalFunc
 	 { let (nm,constraints,pure,clt) = $1 in
-	 Ast0.wrap
-	   (Ast0.MetaLocalFunc(P.clt2mcode nm clt,constraints,pure)) }
+	 Ast0_cocci.wrap
+	   (Ast0_cocci.MetaLocalFunc(P.clt2mcode nm clt,constraints,pure)) }
 
 ident: pure_ident
-         { Ast0.wrap(Ast0.Id(P.id2mcode $1)) }
+         { Ast0_cocci.wrap(Ast0_cocci.Id(P.id2mcode $1)) }
      | wrapped_sym_ident { $1 }
      | TMetaId
          { let (nm,constraints,seed,pure,clt) = $1 in
-         Ast0.wrap(Ast0.MetaId(P.clt2mcode nm clt,constraints,seed,pure)) }
+         Ast0_cocci.wrap(Ast0_cocci.MetaId(P.clt2mcode nm clt,constraints,seed,pure)) }
 
 mident: pure_ident
-         { Ast0.wrap(Ast0.Id(P.id2mcode $1)) }
+         { Ast0_cocci.wrap(Ast0_cocci.Id(P.id2mcode $1)) }
      | wrapped_sym_ident { $1 }
      | TMeta { tmeta_to_ident $1 }
      | TMetaId
          { let (nm,constraints,seed,pure,clt) = $1 in
-         Ast0.wrap(Ast0.MetaId(P.clt2mcode nm clt,constraints,seed,pure)) }
+         Ast0_cocci.wrap(Ast0_cocci.MetaId(P.clt2mcode nm clt,constraints,seed,pure)) }
 
 disj_ident:
        mident { $1 }
@@ -2675,51 +2677,51 @@ disj_ident:
 close_disj_ident(sub_ident):
      | lp=TOPar0 t=midzero_list(sub_ident,sub_ident) rp=TCPar0
 	 { let (mids,code) = t in
-	 Ast0.wrap
-	   (Ast0.DisjId(P.id2mcode lp,code,mids, P.id2mcode rp)) }
+	 Ast0_cocci.wrap
+	   (Ast0_cocci.DisjId(P.id2mcode lp,code,mids, P.id2mcode rp)) }
      | lp=TOPar0 t=andzero_list(sub_ident,sub_ident) rp=TCPar0
 	 { let (mids,code) = t in
-	 Ast0.wrap
-	   (Ast0.ConjId(P.id2mcode lp,code,mids, P.id2mcode rp)) }
+	 Ast0_cocci.wrap
+	   (Ast0_cocci.ConjId(P.id2mcode lp,code,mids, P.id2mcode rp)) }
 
 top_ident:
-  disj_ident { Ast0.wrap(Ast0.OTHER(Ast0.wrap(Ast0.TopId($1)))) }
+  disj_ident { Ast0_cocci.wrap(Ast0_cocci.OTHER(Ast0_cocci.wrap(Ast0_cocci.TopId($1)))) }
 
 type_ident: disj_ident { $1 }
      | TTypeId
-         { Ast0.wrap(Ast0.Id(P.id2mcode $1)) }
+         { Ast0_cocci.wrap(Ast0_cocci.Id(P.id2mcode $1)) }
 
 decl_ident:
        TDeclarerId
-         { Ast0.wrap(Ast0.Id(P.id2mcode $1)) }
+         { Ast0_cocci.wrap(Ast0_cocci.Id(P.id2mcode $1)) }
      | TMetaDeclarer
          { let (nm,constraints,pure,clt) = $1 in
-         Ast0.wrap(Ast0.MetaId(P.clt2mcode nm clt,constraints,Ast.NoVal,pure)) }
+         Ast0_cocci.wrap(Ast0_cocci.MetaId(P.clt2mcode nm clt,constraints,Ast_cocci.NoVal,pure)) }
      | s = close_disj_ident(decl_ident) { s }
 
 iter_ident:
        TIteratorId
-         { Ast0.wrap(Ast0.Id(P.id2mcode $1)) }
+         { Ast0_cocci.wrap(Ast0_cocci.Id(P.id2mcode $1)) }
      | TMetaIterator
          { let (nm,constraints,pure,clt) = $1 in
-         Ast0.wrap(Ast0.MetaId(P.clt2mcode nm clt,constraints,Ast.NoVal,pure)) }
+         Ast0_cocci.wrap(Ast0_cocci.MetaId(P.clt2mcode nm clt,constraints,Ast_cocci.NoVal,pure)) }
 
 typedef_ident:
        pure_ident_or_symbol
-         { Ast0.wrap(Ast0.TypeName(P.id2mcode $1)) }
+         { Ast0_cocci.wrap(Ast0_cocci.TypeName(P.id2mcode $1)) }
      | TMeta { tmeta_to_type $1 }
      | TMetaType
          { let (nm,cstr,pure,clt) = $1 in
-	 Ast0.wrap(Ast0.MetaType(P.clt2mcode nm clt,cstr,pure)) }
+	 Ast0_cocci.wrap(Ast0_cocci.MetaType(P.clt2mcode nm clt,cstr,pure)) }
 
 /*****************************************************************************/
 
 decl_list(decl):
   empty_list_start(one_dec(decl),TEllipsis)
-     { Ast0.wrap
+     { Ast0_cocci.wrap
 	 ($1
-	    (fun _ d -> Ast0.wrap(Ast0.Pdots(P.clt2mcode "..." d)))
-	    (fun c -> Ast0.PComma c)) }
+	    (fun _ d -> Ast0_cocci.wrap(Ast0_cocci.Pdots(P.clt2mcode "..." d)))
+	    (fun c -> Ast0_cocci.PComma c)) }
 
 one_dec(decl):
   decl  { $1 }
@@ -2727,7 +2729,7 @@ one_dec(decl):
     { let (nm,lenname,cstr,pure,clt) = $1 in
     let nm = P.clt2mcode nm clt in
       let lenname = P.dolen clt lenname in
-    Ast0.wrap(Ast0.MetaParamList(nm,lenname,cstr,pure)) }
+    Ast0_cocci.wrap(Ast0_cocci.MetaParamList(nm,lenname,cstr,pure)) }
 
 /* ---------------------------------------------------------------------- */
 /* comma list parser, used for fn params, fn args, enums, initlists,
@@ -2735,7 +2737,7 @@ one_dec(decl):
 
 /* enums: enum_decl, edots_when(TEllipsis,enum_decl_one)
 fun s d -> P.mkedots "..." d
-fun c -> Ast0.EComma c
+fun c -> Ast0_cocci.EComma c
  */
 
 empty_list_start(elem,dotter):
@@ -2746,30 +2748,30 @@ nonempty_list_start(elem,dotter): /* dots allowed */
   element=elem { fun build_dots build_comma -> [element] }
 | element=elem comma=TComma
     { fun build_dots build_comma ->
-      element::[Ast0.wrap(build_comma(P.clt2mcode "," comma))] }
+      element::[Ast0_cocci.wrap(build_comma(P.clt2mcode "," comma))] }
 | element=elem comma=TComma remainder=nonempty_list_start(elem,dotter)
     { fun build_dots build_comma ->
-      element::(Ast0.wrap(build_comma(P.clt2mcode "," comma)))::
+      element::(Ast0_cocci.wrap(build_comma(P.clt2mcode "," comma)))::
       (remainder build_dots build_comma) }
 | TNothing list=nonempty_list_start(elem,dotter) { list }
 | dotter=dotter { fun build_dots build_comma -> [(build_dots "..." dotter)] }
 | dotter=dotter comma=TComma
       { fun build_dots build_comma ->
-	[(build_dots "..." dotter);Ast0.wrap(build_comma(P.clt2mcode "," comma))] }
+	[(build_dots "..." dotter);Ast0_cocci.wrap(build_comma(P.clt2mcode "," comma))] }
 | dotter=dotter comma=TComma remainder=continue_list(elem,dotter)
     { fun build_dots build_comma ->
       (build_dots "..." dotter)::
-      (Ast0.wrap(build_comma(P.clt2mcode "," comma)))::
+      (Ast0_cocci.wrap(build_comma(P.clt2mcode "," comma)))::
       (remainder build_dots build_comma) }
 
 continue_list(elem,dotter): /* dots not allowed */
   element=elem { fun build_dots build_comma -> [element] }
 | element=elem comma=TComma
     { fun build_dots build_comma ->
-      element::[Ast0.wrap(build_comma(P.clt2mcode "," comma))] }
+      element::[Ast0_cocci.wrap(build_comma(P.clt2mcode "," comma))] }
 | element=elem comma=TComma remainder=nonempty_list_start(elem,dotter)
     { fun build_dots build_comma ->
-      element::(Ast0.wrap(build_comma(P.clt2mcode "," comma)))::
+      element::(Ast0_cocci.wrap(build_comma(P.clt2mcode "," comma)))::
       (remainder build_dots build_comma) }
 | TNothing list=nonempty_list_start(elem,dotter) { list }
 
@@ -2782,7 +2784,7 @@ need to find some appropriate delimiter for it, but it has not been used much
 so just drop it */
 /*error_words:
     TError TWords TEq TOCro cl=comma_list(dexpr) TCCro
-      { [Ast0.wrap(Ast0.ERRORWORDS(cl))] }
+      { [Ast0_cocci.wrap(Ast0_cocci.ERRORWORDS(cl))] }
 */
 
 /* ---------------------------------------------------------------------- */
@@ -2816,27 +2818,27 @@ when_body_sequence.
 
 /* doesn't allow only ... */
 minus_start:
-  fundecl                { [Ast0.wrap(Ast0.OTHER($1))] }
-| ctype                  { [Ast0.wrap(Ast0.OTHER(Ast0.wrap(Ast0.Ty($1))))] }
-| top_init          { [Ast0.wrap(Ast0.OTHER(Ast0.wrap(Ast0.TopInit($1))))] }
+  fundecl                { [Ast0_cocci.wrap(Ast0_cocci.OTHER($1))] }
+| ctype                  { [Ast0_cocci.wrap(Ast0_cocci.OTHER(Ast0_cocci.wrap(Ast0_cocci.Ty($1))))] }
+| top_init          { [Ast0_cocci.wrap(Ast0_cocci.OTHER(Ast0_cocci.wrap(Ast0_cocci.TopInit($1))))] }
 | toplevel_seq_startne(toplevel_after_dots_init)
-    { List.map (function x -> Ast0.wrap(Ast0.OTHER(x))) $1 }
+    { List.map (function x -> Ast0_cocci.wrap(Ast0_cocci.OTHER(x))) $1 }
 
 toplevel_seq_startne(after_dots_init):
   a=stm_dots_ell b=after_dots_init           { a::b }
 | a=stm_dots_nest b=after_dots_init           { a::b }
 | a=stm_dots_nest                      { [a] }
-| expr toplevel_after_exp            { (Ast0.wrap(Ast0.Exp($1)))::$2 }
+| expr toplevel_after_exp            { (Ast0_cocci.wrap(Ast0_cocci.Exp($1)))::$2 }
 | decl_statement_expr toplevel_after_stm  { $1@$2 }
 
 toplevel_seq_start(after_dots_init):
   stm_dots after_dots_init           { $1::$2 }
-| expr toplevel_after_exp            { (Ast0.wrap(Ast0.Exp($1)))::$2 }
+| expr toplevel_after_exp            { (Ast0_cocci.wrap(Ast0_cocci.Exp($1)))::$2 }
 | decl_statement_expr toplevel_after_stm  { $1@$2 }
 
 toplevel_after_dots_init:
   TNothing toplevel_after_exp        {$2}
-| expr toplevel_after_exp            {(Ast0.wrap(Ast0.Exp($1)))::$2}
+| expr toplevel_after_exp            {(Ast0_cocci.wrap(Ast0_cocci.Exp($1)))::$2}
 | decl_statement_expr toplevel_after_stm  {$1@$2}
 
 toplevel_after_exp:
@@ -2846,7 +2848,7 @@ toplevel_after_exp:
 toplevel_after_dots:
   /* empty */                        {[]}
 | TNothing toplevel_after_exp        {$2}
-| expr toplevel_after_exp            {(Ast0.wrap(Ast0.Exp($1)))::$2}
+| expr toplevel_after_exp            {(Ast0_cocci.wrap(Ast0_cocci.Exp($1)))::$2}
 | decl_statement_expr toplevel_after_stm  {$1@$2}
 
 toplevel_after_stm:
@@ -2859,50 +2861,50 @@ top_init:
     { if P.struct_initializer $2
     then
       let il = P.drop_dot_commas $2 in
-      Ast0.wrap(Ast0.InitList(P.clt2mcode "{" $1,il,P.clt2mcode "}" $3,false))
+      Ast0_cocci.wrap(Ast0_cocci.InitList(P.clt2mcode "{" $1,il,P.clt2mcode "}" $3,false))
     else
-      Ast0.wrap(Ast0.InitList(P.clt2mcode "{" $1,$2,P.clt2mcode "}" $3,true)) }
+      Ast0_cocci.wrap(Ast0_cocci.InitList(P.clt2mcode "{" $1,$2,P.clt2mcode "}" $3,true)) }
 
 /* ------------------------------------------------------------------------ */
 /* Plus top level */
 
 /* does allow only ... also allows multiple top-level functions */
 plus_start:
-  ctype                   { [Ast0.wrap(Ast0.OTHER(Ast0.wrap(Ast0.Ty($1))))] }
-| top_init           { [Ast0.wrap(Ast0.OTHER(Ast0.wrap(Ast0.TopInit($1))))] }
+  ctype                   { [Ast0_cocci.wrap(Ast0_cocci.OTHER(Ast0_cocci.wrap(Ast0_cocci.Ty($1))))] }
+| top_init           { [Ast0_cocci.wrap(Ast0_cocci.OTHER(Ast0_cocci.wrap(Ast0_cocci.TopInit($1))))] }
 | stm_dots plus_after_dots
-                                          { (Ast0.wrap(Ast0.OTHER($1)))::$2 }
+                                          { (Ast0_cocci.wrap(Ast0_cocci.OTHER($1)))::$2 }
 | expr plus_after_exp
-                     { (Ast0.wrap(Ast0.OTHER(Ast0.wrap(Ast0.Exp($1)))))::$2 }
-| fundecl plus_after_stm                     { Ast0.wrap(Ast0.OTHER($1))::$2 }
+                     { (Ast0_cocci.wrap(Ast0_cocci.OTHER(Ast0_cocci.wrap(Ast0_cocci.Exp($1)))))::$2 }
+| fundecl plus_after_stm                     { Ast0_cocci.wrap(Ast0_cocci.OTHER($1))::$2 }
 | decl_statement_expr plus_after_stm
-                { (List.map (function x -> Ast0.wrap(Ast0.OTHER(x))) $1)@$2 }
+                { (List.map (function x -> Ast0_cocci.wrap(Ast0_cocci.OTHER(x))) $1)@$2 }
 
 plus_after_exp:
   /* empty */                                                            {[]}
-| stm_dots plus_after_dots                { (Ast0.wrap(Ast0.OTHER($1)))::$2 }
+| stm_dots plus_after_dots                { (Ast0_cocci.wrap(Ast0_cocci.OTHER($1)))::$2 }
 
 plus_after_dots:
   /* empty */                                                            {[]}
 | TNothing plus_after_exp                                                {$2}
 | expr plus_after_exp
-                     { (Ast0.wrap(Ast0.OTHER(Ast0.wrap(Ast0.Exp($1)))))::$2 }
-| fundecl plus_after_stm                     { Ast0.wrap(Ast0.OTHER($1))::$2 }
+                     { (Ast0_cocci.wrap(Ast0_cocci.OTHER(Ast0_cocci.wrap(Ast0_cocci.Exp($1)))))::$2 }
+| fundecl plus_after_stm                     { Ast0_cocci.wrap(Ast0_cocci.OTHER($1))::$2 }
 | decl_statement_expr plus_after_stm
-                { (List.map (function x -> Ast0.wrap(Ast0.OTHER(x))) $1)@$2 }
+                { (List.map (function x -> Ast0_cocci.wrap(Ast0_cocci.OTHER(x))) $1)@$2 }
 
 plus_after_stm:
   /* empty */                                                            {[]}
-| stm_dots plus_after_dots                { (Ast0.wrap(Ast0.OTHER($1)))::$2 }
-| fundecl plus_after_stm                     { Ast0.wrap(Ast0.OTHER($1))::$2 }
+| stm_dots plus_after_dots                { (Ast0_cocci.wrap(Ast0_cocci.OTHER($1)))::$2 }
+| fundecl plus_after_stm                     { Ast0_cocci.wrap(Ast0_cocci.OTHER($1))::$2 }
 | decl_statement plus_after_stm
-                { (List.map (function x -> Ast0.wrap(Ast0.OTHER(x))) $1)@$2 }
+                { (List.map (function x -> Ast0_cocci.wrap(Ast0_cocci.OTHER(x))) $1)@$2 }
 
 /* ------------------------------------------------------------------------ */
 /* Function body */
 
 fun_start:
-  fun_after_stm  { Ast0.wrap $1 }
+  fun_after_stm  { Ast0_cocci.wrap $1 }
 
 fun_after_stm:
   /* empty */                  {[]}
@@ -2912,7 +2914,7 @@ fun_after_stm:
 fun_after_dots:
   /* empty */                  {[]}
 | TNothing fun_after_exp       {$2}
-| expr fun_after_exp           {Ast0.wrap(Ast0.Exp($1))::$2}
+| expr fun_after_exp           {Ast0_cocci.wrap(Ast0_cocci.Exp($1))::$2}
 | decl_statement_expr fun_after_stm {$1@$2}
 
 fun_after_exp:
@@ -2922,7 +2924,7 @@ fun_after_exp:
 fun_after_dots_or:
   /* empty */                  {[]}
 | TNothing fun_after_exp_or    {$2}
-| expr fun_after_exp_or        {Ast0.wrap(Ast0.Exp($1))::$2}
+| expr fun_after_exp_or        {Ast0_cocci.wrap(Ast0_cocci.Exp($1))::$2}
 | decl_statement_expr fun_after_stm {$1@$2}
 
 fun_after_exp_or:
@@ -2933,12 +2935,12 @@ fun_after_exp_or:
 /* Nest body */
 
 nest_start:
-  nest_after_dots  { Ast0.wrap $1 }
+  nest_after_dots  { Ast0_cocci.wrap $1 }
 
 nest_after_dots:
   decl_statement_expr nest_after_stm {$1@$2}
 | TNothing nest_after_exp       {$2}
-| expr nest_after_exp           {(Ast0.wrap(Ast0.Exp($1)))::$2}
+| expr nest_after_exp           {(Ast0_cocci.wrap(Ast0_cocci.Exp($1)))::$2}
 
 nest_after_stm:
   /* empty */                   {[]}
@@ -2954,29 +2956,29 @@ nest_after_exp:
 
 when_start:
   expr toplevel_after_exp
-    { Ast0.wrap((Ast0.wrap(Ast0.Exp($1)))::$2) }
+    { Ast0_cocci.wrap((Ast0_cocci.wrap(Ast0_cocci.Exp($1)))::$2) }
 | decl_statement toplevel_after_stm
-    { Ast0.wrap($1@$2) }
+    { Ast0_cocci.wrap($1@$2) }
 
 /* ---------------------------------------------------------------------- */
 
 /* arg expr.  may contain a type or a explist metavariable */
 aexpr:
-    dargexpr { Ast0.set_arg_exp $1 }
+    dargexpr { Ast0_cocci.set_arg_exp $1 }
   | TMetaExpList
       { let (nm,lenname,constraints,pure,clt) = $1 in
       let nm = P.clt2mcode nm clt in
       let lenname = P.dolen clt lenname in
-      Ast0.wrap(Ast0.MetaExprList(nm,lenname,constraints,pure)) }
+      Ast0_cocci.wrap(Ast0_cocci.MetaExprList(nm,lenname,constraints,pure)) }
   | ctype
-      { Ast0.set_arg_exp(Ast0.wrap(Ast0.TypeExp($1))) }
+      { Ast0_cocci.set_arg_exp(Ast0_cocci.wrap(Ast0_cocci.TypeExp($1))) }
 
 eexpr_list_option:
     empty_list_start(aexpr,TEllipsis)
-      { Ast0.wrap
+      { Ast0_cocci.wrap
 	  ($1
-	     (fun _ d -> Ast0.wrap(Ast0.Edots(P.clt2mcode "..." d,None)))
-	     (fun c -> Ast0.EComma c)) }
+	     (fun _ d -> Ast0_cocci.wrap(Ast0_cocci.Edots(P.clt2mcode "..." d,None)))
+	     (fun c -> Ast0_cocci.EComma c)) }
 
 /****************************************************************************/
 
@@ -2984,35 +2986,35 @@ eexpr_list_option:
 exec_list:
     /* empty */ { [] }
   | TDotDot exec_front_ident exec_ident exec_list
-      { Ast0.wrap(Ast0.ExecEval(P.clt2mcode ":" $1,$3 $2)) :: $4 }
+      { Ast0_cocci.wrap(Ast0_cocci.ExecEval(P.clt2mcode ":" $1,$3 $2)) :: $4 }
   | TIdent exec_ident2 exec_list
-      { Ast0.wrap(Ast0.ExecToken(P.clt2mcode (fst $1) (snd $1))) ::
-	List.map (function x -> Ast0.wrap(Ast0.ExecToken x)) $2 @ $3 }
-  | token exec_list { Ast0.wrap(Ast0.ExecToken $1) :: $2 }
+      { Ast0_cocci.wrap(Ast0_cocci.ExecToken(P.clt2mcode (fst $1) (snd $1))) ::
+	List.map (function x -> Ast0_cocci.wrap(Ast0_cocci.ExecToken x)) $2 @ $3 }
+  | token exec_list { Ast0_cocci.wrap(Ast0_cocci.ExecToken $1) :: $2 }
   | TEllipsis exec_list
-      { Ast0.wrap(Ast0.ExecDots(P.clt2mcode "..." $1)) :: $2 }
+      { Ast0_cocci.wrap(Ast0_cocci.ExecDots(P.clt2mcode "..." $1)) :: $2 }
 
 exec_front_ident:
-    ident { Ast0.wrap(Ast0.Ident($1)) }
+    ident { Ast0_cocci.wrap(Ast0_cocci.Ident($1)) }
   | TMetaIdExp
      { let (nm,constraints,pure,ty,clt) = $1 in
-     Ast0.wrap
-       (Ast0.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast.ID,pure,None)) }
+     Ast0_cocci.wrap
+       (Ast0_cocci.MetaExpr(P.clt2mcode nm clt,constraints,ty,Ast_cocci.ID,pure,None)) }
   | TMetaExp
      { let (nm,constraints,pure,ty,clt,bitfield) = $1 in
      let bitfield' = Common.map_option (P.dolen clt) bitfield in
-     Ast0.wrap
-       (Ast0.MetaExpr
-	  (P.clt2mcode nm clt,constraints,ty,Ast.ANY,pure,bitfield')) }
+     Ast0_cocci.wrap
+       (Ast0_cocci.MetaExpr
+	  (P.clt2mcode nm clt,constraints,ty,Ast_cocci.ANY,pure,bitfield')) }
 
 exec_ident:
      { function prev -> prev }
  | TDot   disj_ident exec_ident
      { function prev ->
-       $3 (Ast0.wrap(Ast0.RecordAccess(prev, P.clt2mcode "." $1, $2))) }
+       $3 (Ast0_cocci.wrap(Ast0_cocci.RecordAccess(prev, P.clt2mcode "." $1, $2))) }
  | TPtrOp disj_ident exec_ident
      { function prev ->
-       $3 (Ast0.wrap(Ast0.RecordPtAccess(prev, P.clt2mcode "->" $1,
+       $3 (Ast0_cocci.wrap(Ast0_cocci.RecordPtAccess(prev, P.clt2mcode "->" $1,
 				     $2))) }
 
 exec_ident2:
@@ -3076,21 +3078,21 @@ edots_when(dotter,when_grammar):
 
 whens(when_grammar,simple_when_grammar,any_strict):
     t=TWhen e=TNotEq w=when_grammar TLineEnd
-      { [Ast0.WhenNot (P.clt2mcode "when" t, P.clt2mcode "!=" e, w)] }
+      { [Ast0_cocci.WhenNot (P.clt2mcode "when" t, P.clt2mcode "!=" e, w)] }
   | t=TWhen e=TEq w=simple_when_grammar TLineEnd
-      { [Ast0.WhenAlways (P.clt2mcode "when" t, P.clt2mcode "=" e, w)] }
+      { [Ast0_cocci.WhenAlways (P.clt2mcode "when" t, P.clt2mcode "=" e, w)] }
   | t=TWhen l=comma_list(any_strict) TLineEnd
-      { List.map (function x -> Ast0.WhenModifier(P.clt2mcode "when" t,x)) l }
+      { List.map (function x -> Ast0_cocci.WhenModifier(P.clt2mcode "when" t,x)) l }
   | t=TWhenTrue ee=TNotEq e = eexpr TLineEnd
-      { [Ast0.WhenNotTrue (P.clt2mcode "when" t, P.clt2mcode "!=" ee, e)] }
+      { [Ast0_cocci.WhenNotTrue (P.clt2mcode "when" t, P.clt2mcode "!=" ee, e)] }
   | t=TWhenFalse ee=TNotEq e = eexpr TLineEnd
-      { [Ast0.WhenNotFalse (P.clt2mcode "when" t, P.clt2mcode "!=" ee, e)] }
+      { [Ast0_cocci.WhenNotFalse (P.clt2mcode "when" t, P.clt2mcode "!=" ee, e)] }
 
 any_strict:
-    TAny    { Ast.WhenAny }
-  | TStrict { Ast.WhenStrict }
-  | TForall { Ast.WhenForall }
-  | TExists { Ast.WhenExists }
+    TAny    { Ast_cocci.WhenAny }
+  | TStrict { Ast_cocci.WhenStrict }
+  | TForall { Ast_cocci.WhenForall }
+  | TExists { Ast_cocci.WhenExists }
 
 /*****************************************************************************
 *
@@ -3099,21 +3101,21 @@ any_strict:
 
 iso_main:
   TIsoExpression e1=eexpr el=list(iso(eexpr)) EOF
-    { let fn x = Ast0.ExprTag x in P.iso_adjust fn fn e1 el }
+    { let fn x = Ast0_cocci.ExprTag x in P.iso_adjust fn fn e1 el }
 | TIsoArgExpression e1=eexpr el=list(iso(eexpr)) EOF
-    { let fn x = Ast0.ArgExprTag x in P.iso_adjust fn fn e1 el }
+    { let fn x = Ast0_cocci.ArgExprTag x in P.iso_adjust fn fn e1 el }
 | TIsoTestExpression e1=eexpr el=list(iso(eexpr)) EOF
-    { let fn x = Ast0.TestExprTag x in P.iso_adjust fn fn e1 el }
+    { let fn x = Ast0_cocci.TestExprTag x in P.iso_adjust fn fn e1 el }
 | TIsoToTestExpression e1=eexpr el=list(iso(eexpr)) EOF
-    { let ffn x = Ast0.ExprTag x in
-      let fn x =  Ast0.TestExprTag x in
+    { let ffn x = Ast0_cocci.ExprTag x in
+      let fn x =  Ast0_cocci.TestExprTag x in
       P.iso_adjust ffn fn e1 el }
 | TIsoStatement s1=iso_statement sl=list(iso(iso_statement)) EOF
-    { let fn x = Ast0.StmtTag x in P.iso_adjust fn fn s1 sl }
+    { let fn x = Ast0_cocci.StmtTag x in P.iso_adjust fn fn s1 sl }
 | TIsoType t1=ctype tl=list(iso(ctype)) EOF
-    { let fn x = Ast0.TypeCTag x in P.iso_adjust fn fn t1 tl }
+    { let fn x = Ast0_cocci.TypeCTag x in P.iso_adjust fn fn t1 tl }
 | TIsoTopLevel e1=nest_start el=list(iso(nest_start)) EOF
-    { let fn x = Ast0.DotsStmtTag x in P.iso_adjust fn fn e1 el }
+    { let fn x = Ast0_cocci.DotsStmtTag x in P.iso_adjust fn fn e1 el }
 | TIsoDeclaration d1=decl_var dl=list(iso(decl_var)) EOF
     { let check_one = function
 	[x] -> x
@@ -3128,7 +3130,7 @@ iso_main:
 	    Common.Left x -> Common.Left(check_one x)
 	  | Common.Right x -> Common.Right(check_one x))
 	dl in
-    let fn x = Ast0.DeclTag x in P.iso_adjust fn fn d1 dl }
+    let fn x = Ast0_cocci.DeclTag x in P.iso_adjust fn fn d1 dl }
 
 iso(term):
     TIso t=term { Common.Left t }
@@ -3150,15 +3152,15 @@ never_used: TDirective { () }
 
 script_meta_main:
     py=pure_ident TMPtVirg
-  { ((Some (P.id2name py), None), None, Ast.NoMVInit) }
+  { ((Some (P.id2name py), None), None, Ast_cocci.NoMVInit) }
   | py=pure_ident script_name_decl_ext TMPtVirg
   { ((Some (P.id2name py), None), Some (fst $2), snd $2) }
   | TOPar TUnderscore TComma ast=pure_ident TCPar script_name_decl TMPtVirg
-  { ((None, Some (P.id2name ast)), Some $6, Ast.NoMVInit) }
+  { ((None, Some (P.id2name ast)), Some $6, Ast_cocci.NoMVInit) }
   | TOPar str=pure_ident TComma TUnderscore TCPar script_name_decl_ext TMPtVirg
   { ((Some (P.id2name str), None), Some (fst $6), snd $6) }
   | TOPar str=pure_ident TComma ast=pure_ident TCPar script_name_decl TMPtVirg
-  { ((Some (P.id2name str), Some (P.id2name ast)), Some $6, Ast.NoMVInit) }
+  { ((Some (P.id2name str), Some (P.id2name ast)), Some $6, Ast_cocci.NoMVInit) }
 
 script_name_decl:
     TShLOp checked_meta_name { $2 }
@@ -3174,31 +3176,31 @@ checked_meta_name:
 	   Common.union_set [nm]
 	     !Iteration.parsed_virtual_identifiers;
         let name = ("virtual", nm) in
-        let mv = Ast.MetaIdDecl(Ast.NONE,name) in
+        let mv = Ast_cocci.MetaIdDecl(Ast_cocci.NONE,name) in
         (name,mv) }
   | TMerge TDot cocci=pure_ident
       { let nm = P.id2name cocci in
         let name = ("merge", nm) in
-        let mv = Ast.MetaIdDecl(Ast.NONE,name) in
+        let mv = Ast_cocci.MetaIdDecl(Ast_cocci.NONE,name) in
         (name, mv) }
 
 script_name_decl_ext:
-    script_name_decl { ($1,Ast.NoMVInit) }
+    script_name_decl { ($1,Ast_cocci.NoMVInit) }
   | script_name_decl TEq TString
     { let (nm,mv) = $1 in
       match mv with
-	Ast.MetaPosDecl _ ->
+	Ast_cocci.MetaPosDecl _ ->
 	  raise
 	    (Semantic_cocci.Semantic
 	       "default value of position variable should be a list")
       | _ ->
 	  let (s,_,clt) = $3 in
-	  ($1,Ast.MVInitString s) }
+	  ($1,Ast_cocci.MVInitString s) }
   | script_name_decl TEq TOCro TCCro
     { let (nm,mv) = $1 in
       match mv with
-	Ast.MetaPosDecl _ ->
-	  ($1,Ast.MVInitPosList) (* just empty, so nothing to record *)
+	Ast_cocci.MetaPosDecl _ ->
+	  ($1,Ast_cocci.MVInitPosList) (* just empty, so nothing to record *)
       | _ ->
 	  raise
 	    (Semantic_cocci.Semantic
@@ -3206,7 +3208,7 @@ script_name_decl_ext:
 
 script_meta_virt_nofresh_main:
     py=pure_ident script_virt_name_decl TMPtVirg
-  { ((Some (P.id2name py), None), Some $2, Ast.NoMVInit) }
+  { ((Some (P.id2name py), None), Some $2, Ast_cocci.NoMVInit) }
 
 script_virt_name_decl:
     TShLOp TVirtual TDot cocci=pure_ident
@@ -3215,12 +3217,12 @@ script_virt_name_decl:
 	   Common.union_set [nm]
 	     !Iteration.parsed_virtual_identifiers;
         let name = ("virtual", nm) in
-        let mv = Ast.MetaIdDecl(Ast.NONE,name) in
+        let mv = Ast_cocci.MetaIdDecl(Ast_cocci.NONE,name) in
         (name,mv) }
   | TShLOp TMerge TDot cocci=pure_ident
       { let nm = P.id2name cocci in
         let name = ("merge", nm) in
-        let mv = Ast.MetaIdDecl(Ast.NONE,name) in
+        let mv = Ast_cocci.MetaIdDecl(Ast_cocci.NONE,name) in
         (name,mv) }
 
 %inline
@@ -3365,14 +3367,14 @@ anything: /* used for script code */
  | TSub { "<=" }
  | TLogOp
      { match fst $1 with
-       Ast.SupEq -> ">=" | Ast.InfEq -> "<="
-     | Ast.Inf -> "<" | Ast.Sup -> ">"
+       Ast_cocci.SupEq -> ">=" | Ast_cocci.InfEq -> "<="
+     | Ast_cocci.Inf -> "<" | Ast_cocci.Sup -> ">"
      | _ -> failwith "bad log op" }
  | TShLOp { "<<" }
  | TShROp { ">>" }
  | TDmOp
      { match fst $1 with
-       Ast.Div -> "/" | Ast.Mod -> "%" | _ -> failwith "bad op" }
+       Ast_cocci.Div -> "/" | Ast_cocci.Mod -> "%" | _ -> failwith "bad op" }
  | TPlus { "+" }
  | TMinus { "-" }
  | TMul { "*" }
@@ -3391,10 +3393,10 @@ anything: /* used for script code */
  | TPtVirg { ";" }
  | TOpAssign
      { match fst $1 with
-       Ast.Minus -> "-=" | Ast.Plus -> "+=" | Ast.Mul -> "*=" | Ast.Div -> "/="
-     | Ast.Mod -> "%" | Ast.And -> "&=" | Ast.Or -> "|=" | Ast.Xor -> "^="
-     | Ast.Max -> ">?=" | Ast.Min -> "<?=" | Ast.DecLeft -> "<<="
-     | Ast.DecRight -> ">>=" }
+       Ast_cocci.Minus -> "-=" | Ast_cocci.Plus -> "+=" | Ast_cocci.Mul -> "*=" | Ast_cocci.Div -> "/="
+     | Ast_cocci.Mod -> "%" | Ast_cocci.And -> "&=" | Ast_cocci.Or -> "|=" | Ast_cocci.Xor -> "^="
+     | Ast_cocci.Max -> ">?=" | Ast_cocci.Min -> "<?=" | Ast_cocci.DecLeft -> "<<="
+     | Ast_cocci.DecRight -> ">>=" }
 
  | TIso { "<=>" }
  | TRightIso { "=>" }


### PR DESCRIPTION
Hi, I suggest these changes. Menhir now relies on OCaml's inferred types in a deeper way than it used to, and declaring module aliases causes the inferred types to be wrong (they refer to the local alias, not the name that is visible outside).