### PR TITLE
Makefile: Ensure target directory exists for `install-python`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,7 @@ install-spgen : tools/spgen/source/spgen$(TOOLS_SUFFIX)
 
 .PHONY : install-python
 install-python:
+	$(MKDIR_P) $(DESTDIR)$(LIBDIR)/python/coccilib
 	$(INSTALL_DATA) python/coccilib/*.py \
 		$(DESTDIR)$(LIBDIR)/python/coccilib
 


### PR DESCRIPTION
Encountered this when building and installing Coccinelle fresh from source. With the patch, `make install` on a clean machine completes successfully.

Fixes: #196