### PR TITLE
Fix pkglibdir path

### DIFF
--- a/globals/config.ml.in
+++ b/globals/config.ml.in
@@ -33,8 +33,9 @@ let path =
     if Sys.file_exists (Filename.concat exec_dir "standard.iso") then
       exec_dir
     else
+      let exec_prefix = Filename.dirname exec_dir in
       let libdir =
-        Str.global_replace (Str.regexp "[$]{exec_prefix}") exec_dir "@libdir@"
+        Str.global_replace (Str.regexp "[$]{exec_prefix}") exec_prefix "@libdir@"
       in
       Filename.concat libdir "coccinelle"
 


### PR DESCRIPTION
After 5016596228804588c96f0059818dd937e636d7ab, Coccinelle would not work properly on Nix
and warnings like the following one will be displayed on startup:

	warning: Can't find macro file: /nix/store/qsf3rvxq4gpfazmdps3mx623nkd5mc25-coccinelle-1.1.1/bin/lib/coccinelle/standard.h

It was caused by using bindir rather than its parent directory, which is the exec_prefix.

Signed-off-by: Jan Tojnar <jtojnar@gmail.com>
