### PR TITLE
Fix unportable test(1) operator.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -331,10 +331,10 @@ AS_IF([test "x$enable_pcre_syntax" != "xno"],
   ],
   [dnl
     AC_CHECK_COCCI_EXTPKG([pcre])  dnl  will set $enable_pcre to 'yes', 'no', or 'local'
-    AS_IF([test "x$enable_pcre" == "xyes"],
+    AS_IF([test "x$enable_pcre" = "xyes"],
     [dnl
       AC_MSG_CHECKING([if pcre depends on bytes])
-      AS_IF([test "x`$OCAMLFIND query -r -format '%p' pcre 2>/dev/null | grep bytes`" == "xbytes"],
+      AS_IF([test "x`$OCAMLFIND query -r -format '%p' pcre 2>/dev/null | grep bytes`" = "xbytes"],
       [dnl
         AC_MSG_RESULT([yes])
         AC_MSG_CHECKING([if bytes is an actual module])


### PR DESCRIPTION
Only bash supports '==', POSIX requires '='.