### PR TITLE
Fix libdir in globals/config.ml.in

### DIFF
--- a/globals/config.ml.in
+++ b/globals/config.ml.in
@@ -42,13 +42,13 @@ let path =
     else
       (* Otherwise, we suppose that coccinelle has been installed (make
          install), and that standard.iso is installed in $libdir, where
-         $libdir is $exec_prefix/lib.
-         The default value for $bindir is $exec_prefix/bin.
-         Therefore, we should take for $exec_prefix the parent directory
-         of $bindir.*)
+         $libdir is ${exec_prefix}/lib by default. Rewrite "${exec_prefix}"
+         into its actual value, considering that it could also contain
+         "${prefix}". *)
       let libdir =
-        Str.global_replace (Str.regexp "[$]{exec_prefix}")
-          (Filename.dirname bin_dir) "@libdir@"
+        Str.global_replace (Str.regexp "[$]{prefix}") "@prefix@"
+          (Str.global_replace (Str.regexp "[$]{exec_prefix}")
+            "@exec_prefix@" "@libdir@")
       in
       Filename.concat libdir "coccinelle"
 


### PR DESCRIPTION
When rewriting the `$exec_prefix` part of libdir, use the actual value of exec_prefix, rather than the parent directory of bindir. Although bindir is ${exec_prefix}/bin by default, it can be overridden by passing an argument to ./configure, in which case the paths to standard.iso and standard.h would be deduced incorrectly.

Fixes: 540888ff426e ("Fix 263: wrong default path for COCCINELLE_HOME")