### PR TITLE
Fix combined struct definition with variable declaration

### DIFF
--- a/parsing_c/type_c.ml
+++ b/parsing_c/type_c.ml
@@ -224,7 +224,9 @@ let structdef_to_struct_name ty =
           qu, attr, Ast_c.mk_tybis (StructUnionName (su, s)) [i1;i2]
       | None, _ ->
           ty
-      | x -> raise (Impossible 126)
+      (* Handle the case of combined struct definition with variable declaration *)
+      | Some s, _ ->
+          qu, attr, Ast_c.mk_tybis (StructUnionName (su, s)) (Common.take 2 iis)
       )
   | _ -> raise (Impossible 127)
 


### PR DESCRIPTION
Fixes handling of struct definition and variable declaration of this type, which resulted in

bschubert2@imesrv6 red>spatch --sp-file find_bug.cocci --c++=17 coccinelle_bug_example.cpp init_defs_builtins: /usr/lib/coccinelle/standard.h Starting the test...
HANDLING: coccinelle_bug_example.cpp
Fatal error: exception Coccinelle_modules.Common.Impossible(126)

// This struct definition with combined variable declaration fails Coccinelle parsing struct example : public base_type_t {
    example_struct_t() : base_type_t()
        { }

    void do_something() {
        MYPRINT(0, 0, 0, "Testing %s %d", member1.c_str(), member2);
    }

    std::string member1 = {"test"};
    int member2 = {42};
} global_instance1;  // This form causes Coccinelle to fail

The patch was created wit Augment AI, I'm not familar with Coccinelle code.